### PR TITLE
Style: accent-driven control states

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,15 +43,24 @@
   .status{display:flex;gap:6px;align-items:center;flex-wrap:wrap;max-width:44%}
   .pill{border-radius:999px;padding:2px 8px;font-size:11px;border:1px solid var(--border);background:var(--chip);opacity:.72}
   .ok{color:var(--ok)} .warn{color:var(--warn)} .bad{color:var(--bad)}
-  .chip{padding:6px 10px;border:1px solid var(--border);border-radius:12px;font-size:14px;background:var(--chip);display:inline-flex;gap:8px;align-items:center;color:var(--ink)}
+  .chip{padding:6px 10px;border:1px solid var(--border);border-radius:12px;font-size:14px;background:var(--chip);display:inline-flex;gap:8px;align-items:center;color:var(--ink);transition:background-color .15s ease,border-color .15s ease,box-shadow .15s ease}
+  .chip:hover{border-color:var(--accent);box-shadow:0 0 0 1px var(--accent)}
+  .chip:focus-visible{outline:3px solid var(--accent);outline-offset:2px}
   .chip.danger{background:var(--bad);border-color:var(--bad);color:#fff}
+  .chip.danger:hover{border-color:var(--accent-2);box-shadow:0 0 0 1px var(--accent-2)}
+  .chip.danger:focus-visible{outline-color:var(--accent-2)}
 
   /* Controls */
   .controls{padding:10px 16px;display:grid;grid-template-columns:1fr auto;gap:8px;align-items:center}
   .ctrl-row{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
-  .btn{padding:8px 12px;border:1px solid var(--border);border-radius:12px;background:var(--btn);color:var(--btn-text);cursor:pointer}
-  .btn:active{transform:translateY(1px)}
-  select,input[type="text"]{height:36px;padding:6px 8px;border:1px solid var(--border);border-radius:10px;background:var(--surface);color:var(--ink)}
+  .btn{padding:8px 12px;border:1px solid var(--border);border-radius:12px;background:var(--btn);color:var(--btn-text);cursor:pointer;transition:background-color .15s ease,border-color .15s ease,color .15s ease,box-shadow .15s ease,transform .15s ease}
+  .btn:hover{border-color:var(--accent);box-shadow:0 0 0 1px var(--accent)}
+  .btn:focus-visible{outline:3px solid var(--accent);outline-offset:2px}
+  .btn:active{transform:translateY(1px);border-color:var(--accent-2);box-shadow:0 0 0 1px var(--accent-2)}
+  #saveBtn:focus-visible,.drawer a.btn:focus-visible{outline-color:var(--accent-2)}
+  select,input[type="text"],input[type="number"]{height:36px;padding:6px 8px;border:1px solid var(--border);border-radius:10px;background:var(--surface);color:var(--ink);transition:border-color .15s ease,box-shadow .15s ease}
+  select:focus,input[type="text"]:focus,input[type="number"]:focus{border-color:var(--accent);box-shadow:0 0 0 1px var(--accent);outline:none}
+  select:focus-visible,input[type="text"]:focus-visible,input[type="number"]:focus-visible{outline:3px solid var(--accent);outline-offset:2px}
   .vu{height:12px;background:#eaeaf3;border-radius:12px;overflow:hidden;min-width:160px;flex:1}
   .vu>div{height:100%;width:0;background:#2ee6a6;transition:width .08s}
 
@@ -60,7 +69,8 @@
   body.stacked .grid{grid-template-columns:1fr}
 
   .panel{background:var(--surface);border:1px solid var(--border);border-radius:16px;display:flex;flex-direction:column;min-height:0}
-  .panel .head{padding:12px 16px;border-bottom:1px solid var(--border);font-weight:600;display:flex;align-items:center;gap:10px}
+  .panel .head{padding:12px 16px;border-bottom:1px solid var(--border);font-weight:600;display:flex;align-items:center;gap:10px;position:relative}
+  .panel .head::after{content:"";position:absolute;left:16px;bottom:-1px;width:56px;height:3px;border-radius:2px;background:linear-gradient(90deg,var(--accent),var(--accent-2));pointer-events:none}
   .panel .body{padding:12px 16px;overflow:auto;min-height:0;overscroll-behavior:contain}
   .footer{padding:10px 16px;border-top:1px solid var(--border);font-size:12px;color:var(--sub);display:flex;gap:8px;align-items:center}
 
@@ -71,6 +81,8 @@
   /* Settings drawer */
   .drawer{position:fixed;right:12px;top:76px;bottom:12px;width:460px;background:#f3f6ff;border:1px solid #dbe1ff;border-radius:14px;padding:10px 12px;overflow:auto;display:none;z-index:20}
   .drawer .group{background:#fff;border:1px solid #dbe1ff;border-radius:10px;padding:10px;margin-bottom:10px}
+  .drawer h4{margin:0 0 8px;display:flex;align-items:center;gap:8px}
+  .drawer h4::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--accent)}
   .sub{color:#6a7180;font-size:12px}
 
   /* Version at bottom */
@@ -84,7 +96,10 @@
 
 /* Bottom footer bar */
 .footbar{position:fixed;right:12px;bottom:8px;display:flex;gap:8px;align-items:center;z-index:25}
-.footbtn{padding:6px 8px;border:1px solid var(--border);border-radius:10px;background:var(--chip);cursor:pointer;font-size:14px}
+.footbtn{padding:6px 8px;border:1px solid var(--border);border-radius:10px;background:var(--chip);cursor:pointer;font-size:14px;transition:background-color .15s ease,border-color .15s ease,box-shadow .15s ease}
+.footbtn:hover{border-color:var(--accent);box-shadow:0 0 0 1px var(--accent)}
+.footbtn:focus-visible{outline:3px solid var(--accent);outline-offset:2px}
+.footbtn:active{border-color:var(--accent-2);box-shadow:0 0 0 1px var(--accent-2)}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add accent and secondary accent feedback for button hover, focus, and active states
- reinforce panel and drawer headings with accent cues to clarify hierarchy
- update inputs and footer toggle to share the new accessible focus outline styling

## Testing
- node server.mjs
- curl -I http://127.0.0.1:8787/
- curl -I http://127.0.0.1:8800/ (fails: connection refused; API served on 8787)

Smoke Test:
- node server.mjs
- curl http://127.0.0.1:8800/ (connection refused; API available on 8787 here)
- Title font and Nugget render (static asset references unchanged in index.html)


------
https://chatgpt.com/codex/tasks/task_e_68c903cab0d4832d8c2714b2e4488ee7