### PR TITLE
feat: bundle web UI into the Tauri shell

### DIFF
--- a/.scripts/prepare-tauri-assets.mjs
+++ b/.scripts/prepare-tauri-assets.mjs
@@ -1,0 +1,55 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const tauriRoot = path.join(repoRoot, 'src-tauri');
+const targetRoot = path.join(tauriRoot, 'target');
+const uiDist = path.join(targetRoot, 'ui-dist');
+const runtimeDist = path.join(targetRoot, 'runtime');
+
+async function emptyDir(dir) {
+  await fs.rm(dir, { recursive: true, force: true });
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function copyRecursive(src, dest) {
+  const stats = await fs.stat(src);
+  if (stats.isDirectory()) {
+    await fs.mkdir(dest, { recursive: true });
+    const entries = await fs.readdir(src);
+    for (const entry of entries) {
+      await copyRecursive(path.join(src, entry), path.join(dest, entry));
+    }
+    return;
+  }
+  await fs.mkdir(path.dirname(dest), { recursive: true });
+  await fs.copyFile(src, dest);
+}
+
+async function copyNuggets() {
+  const entries = await fs.readdir(repoRoot);
+  const tasks = entries
+    .filter((name) => name.startsWith('nugget') && name.endsWith('.png'))
+    .map((name) => copyRecursive(path.join(repoRoot, name), path.join(uiDist, name)));
+  await Promise.all(tasks);
+}
+
+async function main() {
+  await emptyDir(uiDist);
+  await emptyDir(runtimeDist);
+
+  await copyRecursive(path.join(repoRoot, 'index.html'), path.join(uiDist, 'index.html'));
+  await copyRecursive(path.join(repoRoot, 'fonts'), path.join(uiDist, 'fonts'));
+  await copyNuggets();
+
+  await copyRecursive(path.join(repoRoot, 'server.mjs'), path.join(runtimeDist, 'server.mjs'));
+  await copyRecursive(path.join(repoRoot, 'server'), path.join(runtimeDist, 'server'));
+}
+
+main().catch((err) => {
+  console.error('[prepare-tauri-assets] Failed:', err);
+  process.exit(1);
+});

--- a/ScribeCat.command
+++ b/ScribeCat.command
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
+set -euo pipefail
 cd "$(dirname "$0")"
-node server.mjs &
-SERVER_PID=$!
-sleep 1
-open "http://127.0.0.1:8787/"
-wait $SERVER_PID
+
+APP_BUNDLE="./src-tauri/target/release/bundle/macos/ScribeCat.app"
+APP_BIN="./src-tauri/target/release/scribecat-app"
+
+if [ -d "$APP_BUNDLE" ]; then
+  open "$APP_BUNDLE"
+  exit 0
+fi
+
+if [ -x "$APP_BIN" ]; then
+  "$APP_BIN" "$@"
+  exit 0
+fi
+
+echo "Desktop build not found; starting tauri dev server..."
+npm run tauri:dev "$@"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,50 +1,80 @@
 #![cfg_attr(all(not(debug_assertions), target_os = "windows"), windows_subsystem = "windows")]
 
-use std::fs::{remove_file, OpenOptions};
-use std::path::PathBuf;
+use std::fs::{create_dir_all, remove_file, OpenOptions};
+use std::net::TcpStream;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::Mutex;
+use std::thread::sleep;
+use std::time::Duration;
 
+use tauri::path::BaseDirectory;
 use tauri::{Manager, RunEvent, WindowEvent};
 
-struct ServerProc(Mutex<Option<Child>>);
-
-fn project_root() -> PathBuf {
-    std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."))
+struct AppState {
+    server: Mutex<Option<Child>>,
+    runtime_dir: PathBuf,
+    log_dir: PathBuf,
 }
 
-fn pid_file_path() -> PathBuf {
-    project_root().join("server/.server.pid")
+fn development_root() -> PathBuf {
+    if let Ok(dir) = std::env::current_dir() {
+        if dir.join("server.mjs").exists() {
+            return dir;
+        }
+    }
+
+    if let Ok(mut exe_path) = std::env::current_exe() {
+        exe_path.pop();
+        if exe_path.join("server.mjs").exists() {
+            return exe_path;
+        }
+    }
+
+    PathBuf::from(".")
 }
 
-fn log_file_path() -> PathBuf {
-    project_root().join("server/scribecat-server.log")
+fn log_file_path(log_dir: &Path) -> PathBuf {
+    log_dir.join("scribecat-server.log")
 }
 
-fn spawn_server() -> std::io::Result<Child> {
-    let cwd = project_root();
-    let log_path = log_file_path();
+fn pid_file_path(log_dir: &Path) -> PathBuf {
+    log_dir.join("scribecat-server.pid")
+}
+
+fn spawn_server(runtime_dir: &Path, log_dir: &Path) -> std::io::Result<Child> {
+    create_dir_all(log_dir)?;
 
     let log_file = OpenOptions::new()
         .create(true)
         .append(true)
-        .open(log_path)?;
+        .open(log_file_path(log_dir))?;
     let log_file_err = log_file.try_clone()?;
 
     let mut child = Command::new("node")
         .arg("server.mjs")
-        .current_dir(&cwd)
+        .current_dir(runtime_dir)
         .stdin(Stdio::null())
         .stdout(Stdio::from(log_file))
         .stderr(Stdio::from(log_file_err))
         .spawn()?;
 
-    let _ = std::fs::write(pid_file_path(), child.id().to_string());
+    let _ = std::fs::write(pid_file_path(log_dir), child.id().to_string());
     Ok(child)
 }
 
-fn terminate_server(child_opt: &mut Option<Child>) {
-    if let Some(child) = child_opt {
+fn wait_for_server_ready() {
+    for _ in 0..50 {
+        if TcpStream::connect("127.0.0.1:8787").is_ok() {
+            return;
+        }
+        sleep(Duration::from_millis(100));
+    }
+}
+
+fn terminate_server(state: &AppState) {
+    let mut guard = state.server.lock().unwrap();
+    if let Some(mut child) = guard.take() {
         #[cfg(target_family = "windows")]
         {
             let _ = Command::new("taskkill")
@@ -57,36 +87,61 @@ fn terminate_server(child_opt: &mut Option<Child>) {
         }
         let _ = child.wait();
     }
-    let _ = remove_file(pid_file_path());
-    *child_opt = None;
+    let _ = remove_file(pid_file_path(&state.log_dir));
 }
 
 fn main() {
-    let server_state = ServerProc(Mutex::new(None));
-
     tauri::Builder::default()
-        .manage(server_state)
         .setup(|app| {
-            let state = app.state::<ServerProc>();
-            let mut guard = state.0.lock().unwrap();
-            if guard.is_none() {
-                let child = spawn_server().map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
-                *guard = Some(child);
+            let handle = app.handle();
+            let path_resolver = handle.path();
+
+            let resource_runtime = path_resolver
+                .resolve("runtime", BaseDirectory::Resource)
+                .ok()
+                .filter(|p| p.exists());
+
+            let (runtime_dir, log_dir) = if let Some(runtime) = resource_runtime {
+                let log_dir = path_resolver
+                    .resolve("logs", BaseDirectory::AppData)
+                    .unwrap_or_else(|_| development_root().join("logs"));
+                (runtime, log_dir)
+            } else {
+                let runtime = development_root();
+                let log_dir = runtime.join("server");
+                (runtime, log_dir)
+            };
+
+            let state = AppState {
+                server: Mutex::new(None),
+                runtime_dir,
+                log_dir,
+            };
+            app.manage(state);
+
+            let state = app.state::<AppState>();
+            {
+                let mut guard = state.server.lock().unwrap();
+                if guard.is_none() {
+                    let child = spawn_server(&state.runtime_dir, &state.log_dir)
+                        .map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
+                    wait_for_server_ready();
+                    *guard = Some(child);
+                }
             }
+
             Ok(())
         })
         .on_window_event(|event| {
             if let WindowEvent::CloseRequested { .. } = event.event() {
-                let state = event.window().state::<ServerProc>();
-                let mut guard = state.0.lock().unwrap();
-                terminate_server(&mut *guard);
+                let state = event.window().state::<AppState>();
+                terminate_server(&state);
             }
         })
         .run(|app_handle, event| match event {
-            RunEvent::ExitRequested { .. } => {
-                let state = app_handle.state::<ServerProc>();
-                let mut guard = state.0.lock().unwrap();
-                terminate_server(&mut *guard);
+            RunEvent::ExitRequested { .. } | RunEvent::Exit { .. } => {
+                let state = app_handle.state::<AppState>();
+                terminate_server(&state);
             }
             _ => {}
         });

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -3,35 +3,35 @@
   "identifier": "com.scribecat.app",
   "productName": "ScribeCat",
   "version": "1.0.0",
-
   "build": {
-    "beforeDevCommand": "",
-    "beforeBuildCommand": "",
-    "devUrl": "index.html",
-    "frontendDist": "."
+    "beforeDevCommand": "node .scripts/prepare-tauri-assets.mjs",
+    "beforeBuildCommand": "node .scripts/prepare-tauri-assets.mjs",
+    "devUrl": "tauri://localhost/index.html",
+    "frontendDist": "target/ui-dist"
   },
-
-  "security": {
-    "csp": null
-  },
-
   "app": {
+    "security": {
+      "csp": null
+    },
     "windows": [
       {
         "title": "ScribeCat",
         "width": 1280,
         "height": 840,
-        "resizable": true
+        "resizable": true,
+        "url": "tauri://localhost/index.html"
       }
     ]
   },
-
   "bundle": {
     "active": true,
     "targets": "all",
     "icon": [
       "icons/scribecat-512.png",
       "icons/icon32.png"
+    ],
+    "resources": [
+      "target/runtime"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- add a build prep script that stages the web UI and Node server into Tauri's target assets before each build/dev run
- load those staged assets from Tauri by updating the config and runtime bootstrap so the Node API is spawned from packaged resources with log handling
- update ScribeCat.command to open the packaged desktop app (or fall back to `tauri dev`) instead of launching the browser against the raw API

## Testing
- `node server.mjs` *(Ctrl+C after startup message)*
- `curl http://127.0.0.1:8787/`
- `npm run tauri:build` *(fails: missing glib-2.0 / gobject-2.0 dev packages in container)*

## Smoke test
- `node server.mjs`
- `curl http://127.0.0.1:8787/`
- Title font & Nugget render: not visually verifiable in headless container; assets are copied into the staged bundle

------
https://chatgpt.com/codex/tasks/task_e_68c9ac4b510c832d868efb25f03593d9