### PR TITLE
fix: adjust Tauri bundle identifier

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "identifier": "com.scribecat.app",
+  "identifier": "com.scribecat.desktop",
   "productName": "ScribeCat",
   "version": "1.0.0",
 


### PR DESCRIPTION
## Summary
- update the Tauri bundle identifier to `com.scribecat.desktop` so it no longer conflicts with the macOS `.app` bundle extension during packaging

## Testing / Smoke Test
- `node server.mjs`
- `curl http://127.0.0.1:8787/`
- Title font and Nugget render (static bundle unchanged)


------
https://chatgpt.com/codex/tasks/task_e_68c9dc5316b4832d97e2d7a92cc034b8