### PR TITLE
fix: point Tauri dev URL at local server

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,15 +7,14 @@
   "build": {
     "beforeDevCommand": "",
     "beforeBuildCommand": "",
-    "devUrl": "index.html",
+    "devUrl": "http://127.0.0.1:8787/",
     "frontendDist": "."
   },
 
-  "security": {
-    "csp": null
-  },
-
   "app": {
+    "security": {
+      "csp": null
+    },
     "windows": [
       {
         "title": "ScribeCat",


### PR DESCRIPTION
## Summary
- update the Tauri config so `build.devUrl` matches the local Node dev server endpoint
- move the CSP stanza under `app.security` to satisfy the Tauri v2 schema validator

## Testing
- `npm run tauri:build` *(fails: Tauri requires `build.frontendDist` to point at a folder that excludes `src-tauri`, `node_modules`, etc.; current project layout still needs that restructure)*

## Smoke Test
- `node server.mjs`
- `curl http://127.0.0.1:8787/`
- UI unchanged in this change set; existing title font and Nugget assets remain intact


------
https://chatgpt.com/codex/tasks/task_e_68c9ceed7924832d9789c40a823b691c