### PR TITLE
chore: install glib dependencies for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/javascript-node:20
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        libglib2.0-dev \
+        libgobject-2.0-dev \
+    && rm -rf /var/lib/apt/lists/*
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+  "name": "ScribeCat",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.defaultProfile.linux": "bash"
+      },
+      "extensions": []
+    }
+  },
+  "forwardPorts": [8787]
+}
+


### PR DESCRIPTION
## Summary
- add a devcontainer image based on the Node 20 template so contributors have a consistent environment
- install the libglib2.0-dev and libgobject-2.0-dev packages in the container to satisfy the Tauri build prerequisites
- forward the ScribeCat server port and keep the default bash terminal profile for VS Code users

## Testing
- node server.mjs
- curl -I http://127.0.0.1:8787/
- Title font & Nugget render: not verified in CLI environment

------
https://chatgpt.com/codex/tasks/task_e_68c9e42dca20832da8170013de7a8cd2