### PR TITLE
build: add asset staging helper for tauri

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+dist-tauri/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,10 @@ ScribeCat — local Node server (`server.mjs`) + static web app in `web/`.
   - `npm ci` (fallback `npm i` if no lockfile)
 - Start dev server:
   - `node server.mjs`
+- Prep desktop build assets before packaging:
+  - `npm run prepare-tauri-assets`
+  - `npm run tauri:build`
+  - `tauri dev` calls the staging helper automatically.
 
 ## Environment
 Provide:
@@ -26,3 +30,4 @@ Provide:
 
 ## Scripts (optional)
 - Test (later): `npm test`
+- Desktop build: `npm run prepare-tauri-assets && npm run tauri:build`

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "node server.mjs",
     "dev": "node server.mjs",
+    "prepare-tauri-assets": "node scripts/prepare-tauri-assets.mjs",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build"
   },

--- a/scripts/prepare-tauri-assets.mjs
+++ b/scripts/prepare-tauri-assets.mjs
@@ -1,0 +1,103 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..");
+const distDir = path.join(projectRoot, "dist-tauri");
+
+async function ensureDir(dir) {
+  if (!dir) return;
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function pathExists(target) {
+  try {
+    await fs.stat(target);
+    return true;
+  } catch (error) {
+    if (error.code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+async function resetDist() {
+  await fs.rm(distDir, { recursive: true, force: true });
+  await fs.mkdir(distDir, { recursive: true });
+}
+
+async function copyFileRelative(src, dest = src) {
+  const srcPath = path.join(projectRoot, src);
+  const destPath = path.join(distDir, dest);
+  if (!(await pathExists(srcPath))) {
+    throw new Error(`Missing required asset: ${src}`);
+  }
+  await ensureDir(path.dirname(destPath));
+  await fs.copyFile(srcPath, destPath);
+}
+
+async function copyDirRelative(src, dest = src) {
+  const srcPath = path.join(projectRoot, src);
+  const destPath = path.join(distDir, dest);
+  if (!(await pathExists(srcPath))) {
+    throw new Error(`Missing required directory: ${src}`);
+  }
+  await ensureDir(path.dirname(destPath));
+  await fs.cp(srcPath, destPath, { recursive: true });
+}
+
+async function copyNuggetImages() {
+  const entries = await fs.readdir(projectRoot);
+  const nuggets = entries.filter((name) => /^nugget.*\.png$/i.test(name));
+  if (!nuggets.length) {
+    throw new Error("No nugget*.png assets found");
+  }
+  for (const file of nuggets) {
+    await copyFileRelative(file);
+  }
+}
+
+async function copyRuntimeDependencies() {
+  const pkgJsonPath = path.join(projectRoot, "package.json");
+  const pkgRaw = await fs.readFile(pkgJsonPath, "utf8");
+  const pkg = JSON.parse(pkgRaw);
+  const dependencies = Object.keys(pkg.dependencies || {});
+  if (!dependencies.length) return;
+
+  const nodeModulesRoot = path.join(projectRoot, "node_modules");
+  const destRoot = path.join(distDir, "node_modules");
+  await ensureDir(destRoot);
+
+  for (const dep of dependencies) {
+    const src = path.join(nodeModulesRoot, dep);
+    if (!(await pathExists(src))) {
+      console.warn(`Skipping missing dependency: ${dep}`);
+      continue;
+    }
+    const dest = path.join(destRoot, dep);
+    await fs.cp(src, dest, { recursive: true });
+  }
+}
+
+async function main() {
+  console.log("Preparing dist-tauri assets...");
+  await resetDist();
+
+  await copyFileRelative("index.html");
+  await copyFileRelative("favicon.ico");
+  await copyNuggetImages();
+
+  await copyDirRelative("icons");
+  await copyDirRelative("fonts");
+  await copyDirRelative("server");
+  await copyFileRelative("server.mjs");
+
+  await copyRuntimeDependencies();
+  console.log("dist-tauri ready.");
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,10 +5,10 @@
   "version": "1.0.0",
 
   "build": {
-    "beforeDevCommand": "",
-    "beforeBuildCommand": "",
+    "beforeDevCommand": "node scripts/prepare-tauri-assets.mjs",
+    "beforeBuildCommand": "node scripts/prepare-tauri-assets.mjs",
     "devUrl": "index.html",
-    "frontendDist": "."
+    "frontendDist": "dist-tauri"
   },
 
   "security": {


### PR DESCRIPTION
## Summary
- add a Node helper to stage frontend and server assets into dist-tauri before packaging
- wire tauri to run the staging helper for dev/build and document the workflow in the contributor notes
- ignore the generated dist-tauri directory

## Testing
- npm run prepare-tauri-assets

## Smoke Test
- node server.mjs
- curl http://127.0.0.1:8787/
- Title font and Nugget render: unchanged (no UI changes in this PR)


------
https://chatgpt.com/codex/tasks/task_e_68c9e4daed2c832db046bfc1c1e5fd6c