### PR TITLE
feat: add Docker-based tauri dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+FROM node:20-bookworm-slim
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    RUSTUP_HOME=/usr/local/rustup \
+    CARGO_HOME=/usr/local/cargo \
+    PATH=/usr/local/cargo/bin:$PATH
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        xvfb \
+        xauth \
+        x11-utils \
+        libgtk-3-0 \
+        libayatana-appindicator3-1 \
+    && if apt-get install -y --no-install-recommends libwebkit2gtk-4.1-0; then \
+        true; \
+    else \
+        apt-get install -y --no-install-recommends libwebkit2gtk-4.0-37; \
+    fi \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | \
+        sh -s -- -y --no-modify-path --default-toolchain stable \
+    && cargo install tauri-cli
+
+WORKDIR /app
+
+COPY package*.json ./
+
+RUN npm ci
+
+COPY . .
+
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["npm", "run", "tauri", "dev"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${DISPLAY:-}" ]; then
+  export DISPLAY=:99
+fi
+
+XVFB_DISPLAY="${DISPLAY}"
+XVFB_PID=""
+
+cleanup() {
+  if [ -n "$XVFB_PID" ] && kill -0 "$XVFB_PID" 2>/dev/null; then
+    kill "$XVFB_PID" 2>/dev/null || true
+    wait "$XVFB_PID" 2>/dev/null || true
+  fi
+}
+
+trap cleanup INT TERM EXIT
+
+if ! xdpyinfo -display "$XVFB_DISPLAY" >/dev/null 2>&1; then
+  Xvfb "$XVFB_DISPLAY" -screen 0 1920x1080x24 -ac +extension GLX +render -noreset &
+  XVFB_PID=$!
+
+  for _ in $(seq 1 20); do
+    if xdpyinfo -display "$XVFB_DISPLAY" >/dev/null 2>&1; then
+      break
+    fi
+    sleep 0.25
+  done
+fi
+
+if ! xdpyinfo -display "$XVFB_DISPLAY" >/dev/null 2>&1; then
+  echo "Failed to start Xvfb on display $XVFB_DISPLAY" >&2
+  exit 1
+fi
+
+exec "$@"


### PR DESCRIPTION
## Scope Summary
- add a Dockerfile for running the Tauri dev workflow in a headless container
- include an entrypoint script that bootstraps Xvfb and forwards the container command once the virtual display is ready

## Migration Notes
- none

## Rollback Plan
- revert this commit

## Risks & Mitigations
- Xvfb startup timing issues → wait-loop with xdpyinfo and exit-on-failure guard
- library availability differences between Debian releases → attempt libwebkit2gtk 4.1 first, then fall back to 4.0

## Validation Plan / Test Matrix
- Desktop smoke test: not run (infrastructure-only change; no runtime code touched)


------
https://chatgpt.com/codex/tasks/task_e_68ca04ab5d9c832d9d4a24ec99d602c2