### PR TITLE
feat: expand theme presets to fifteen options

### DIFF
--- a/index.html
+++ b/index.html
@@ -242,7 +242,10 @@
   "Citrus":     {bg:'#fffdf6',surface:'#ffffff',ink:'#1f1407',sub:'#6b5a44',border:'#efe7d6',brand:'#ffd200',accent:'#ff7d26',accent2:'#0ea5e9',btn:'#fff',btnText:'#1f1407'},
   "Neon Night": {bg:'#0b0e18',surface:'#101425',ink:'#eaf1ff',sub:'#9fb0c9',border:'#1a2140',brand:'#ffd200',accent:'#4be9b9',accent2:'#a78bfa',btn:'#16203a',btnText:'#eaf1ff'},
   "Rose Slate": {bg:'#f9f4f6',surface:'#ffffff',ink:'#28151b',sub:'#6d545f',border:'#ecdbe1',brand:'#ffd200',accent:'#ff5c8a',accent2:'#7c3aed',btn:'#fff',btnText:'#28151b'},
-  "High Noon":  {bg:'#fff8e6',surface:'#ffffff',ink:'#2b1a00',sub:'#7a5a2b',border:'#f1e4c7',brand:'#ffd200',accent:'#d97706',accent2:'#2563eb',btn:'#fff',btnText:'#2b1a00'}
+  "High Noon":  {bg:'#fff8e6',surface:'#ffffff',ink:'#2b1a00',sub:'#7a5a2b',border:'#f1e4c7',brand:'#ffd200',accent:'#d97706',accent2:'#2563eb',btn:'#fff',btnText:'#2b1a00'},
+  "Noir Luxe":  {bg:'#080a12',surface:'#131824',ink:'#f7f9ff',sub:'#9aa3b9',border:'#1f2533',brand:'#ffd200',accent:'#d6a354',accent2:'#4eb1ff',btn:'#1c2432',btnText:'#f7f9ff'},
+  "Porcelain Noir": {bg:'#f5f6fa',surface:'#ffffff',ink:'#131720',sub:'#5b6474',border:'#e2e6ef',brand:'#ffd200',accent:'#2f5df0',accent2:'#b93d7e',btn:'#131720',btnText:'#f5f6fa'},
+  "Emerald Frost": {bg:'#0d1311',surface:'#16201d',ink:'#f0f6f5',sub:'#8ea79f',border:'#22302b',brand:'#ffd200',accent:'#1eb980',accent2:'#4f7bff',btn:'#1f2c27',btnText:'#f0f6f5'}
 };
   themeSel.innerHTML = Object.keys(THEMES).map(n=>`<option>${n}</option>`).join("");
   function applyThemeVars(t){


### PR DESCRIPTION
## Summary
- add Noir Luxe, Porcelain Noir, and Emerald Frost presets to the settings theme list
- rely on the existing select-population logic so the dropdown now enumerates all fifteen themes

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68ca087bac80832dbbb662b73a4ebf9e