### PR TITLE
fix: unify Tauri entry point

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,18 +1,6 @@
 // src-tauri/src/main.rs
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // harmless on macOS
 
-fn main() {
-  // In dev, load env from .env (src-tauri/.env or project-root/.env)
-  #[cfg(debug_assertions)]
-  {
-    let _ = dotenvy::from_filename(".env")
-      .or_else(|_| dotenvy::from_filename("../.env"));
-  }
-
-  tauri::Builder::default()
-    .run(tauri::generate_context!())
-    .expect("error while running tauri application");
-}
 use std::fs::{remove_file, OpenOptions};
 use std::path::PathBuf;
 use std::process::{Child, Command, Stdio};
@@ -75,6 +63,11 @@ fn terminate_server(child_opt: &mut Option<Child>) {
 }
 
 fn main() {
+    #[cfg(debug_assertions)]
+    {
+        let _ = dotenvy::from_filename(".env").or_else(|_| dotenvy::from_filename("../.env"));
+    }
+
     let server_state = ServerProc(Mutex::new(None));
 
     tauri::Builder::default()
@@ -83,7 +76,8 @@ fn main() {
             let state = app.state::<ServerProc>();
             let mut guard = state.0.lock().unwrap();
             if guard.is_none() {
-                let child = spawn_server().map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
+                let child =
+                    spawn_server().map_err(|e| -> Box<dyn std::error::Error> { Box::new(e) })?;
                 *guard = Some(child);
             }
             Ok(())


### PR DESCRIPTION
## Summary
- collapse the duplicate `main` functions into a single Tauri entry point
- keep the development `.env` loading path active inside the surviving startup logic

## Migration Notes
- none required

## Rollback Plan
- revert this commit

## Risks & Mitigations
- Low risk: the change only refactors initialization; existing server startup/teardown paths remain untouched.

## Validation Plan / Test Matrix
- `cargo fmt`
- `cargo check` *(fails in container: missing system glib, expected on this image)*

## Desktop Smoke Test
- not run for this change (startup refactor only; no renderer or asset changes)


------
https://chatgpt.com/codex/tasks/task_e_68ca14dc4cb0832d957a01fec7907954