### PR TITLE
chore: route npm dev through tauri

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,15 @@
 # AGENTS.md
 
 ## Project
-ScribeCat — local Node server (`server.mjs`) + static web app in `web/`.
+ScribeCat — Tauri desktop shell bundling the static web app in `web/` (legacy Node helper in `server.mjs`).
 
 ## Setup
 - Node 20
 - Install deps:
   - `npm ci` (fallback `npm i` if no lockfile)
-- Start dev server:
+- Desktop shell (Tauri):
+  - `npm run tauri -- dev`
+- Legacy HTTP helper (avoid for desktop runtime):
   - `node server.mjs`
 
 ## Environment

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "description": "Local API server and static web app for ScribeCat",
   "scripts": {
     "start": "node server.mjs",
-    "dev": "node server.mjs",
+    "dev": "npm run tauri -- dev",
+    "tauri": "tauri",
     "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build",
-    "tauri": "tauri"
+    "tauri:build": "tauri build"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary
- point `npm run dev` at the Tauri CLI so the desktop shell has a single canonical entrypoint
- update AGENTS instructions to call out `npm run tauri -- dev` and note the legacy Node helper

## Scope
- package.json scripts
- contributor documentation (AGENTS.md)

## Migration Notes
- none

## Rollback Plan
- revert this commit

## Risks
- low tooling risk; the legacy `start` script remains if the Node helper is still required

## Validation
- npm install
- npm run tauri -- dev *(fails: Tauri CLI rejects current tauri.conf.json devUrl/security settings, but the script executes)*

------
https://chatgpt.com/codex/tasks/task_e_68ca14f9b2e4832db5f56df7ce4f58e0