### PR TITLE
chore: align tauri config with v2 schema

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,37 +1,17 @@
 {
-  "$schema": "https://schema.tauri.app/config/2",
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "identifier": "com.scribecat.app",
   "productName": "ScribeCat",
-  "version": "1.0.0",
-
+  "version": "0.1.0",
   "build": {
-    "beforeDevCommand": "",
-    "beforeBuildCommand": "",
-    "devUrl": "index.html",
-    "frontendDist": "."
+    "devUrl": "http://localhost:3000",
+    "frontendDist": "../web"
   },
-
-  "security": {
-    "csp": null
-  },
-
   "app": {
+    "security": { "csp": null },
     "windows": [
-      {
-        "title": "ScribeCat",
-        "width": 1280,
-        "height": 840,
-        "resizable": true
-      }
+      { "title": "ScribeCat", "width": 1100, "height": 760, "resizable": true }
     ]
   },
-
-  "bundle": {
-    "active": true,
-    "targets": "all",
-    "icon": [
-      "icons/scribecat-512.png",
-      "icons/icon32.png"
-    ]
-  }
+  "bundle": {}
 }


### PR DESCRIPTION
## Summary
- replace the Tauri configuration with the minimal v2-compliant file provided
- point devUrl to the local dev server and frontendDist to the bundled web assets
- keep the security CSP disabled and size the ScribeCat window to 1100x760

## Testing
- not run (config only)


------
https://chatgpt.com/codex/tasks/task_e_68ca24457a44832db93902dc9f4b2a87