### PR TITLE
chore: tidy package manifest scripts and dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "scribecat",
       "version": "1.0.0",
       "dependencies": {
+        "@tauri-apps/api": "^2.0.0",
         "dotenv": "^17.2.2"
       },
       "devDependencies": {
@@ -15,6 +16,16 @@
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/@tauri-apps/api": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.8.0.tgz",
+      "integrity": "sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==",
+      "license": "Apache-2.0 OR MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/tauri"
       }
     },
     "node_modules/@tauri-apps/cli": {

--- a/package.json
+++ b/package.json
@@ -4,17 +4,17 @@
   "private": true,
   "type": "module",
   "description": "Local API server and static web app for ScribeCat",
-  "scripts": {
-    "start": "node server.mjs",
-    "dev": "node server.mjs",
-    "tauri:dev": "tauri dev",
-    "tauri:build": "tauri build",
-    "tauri": "tauri"
-  },
   "engines": {
     "node": ">=20"
   },
+  "scripts": {
+    "dev": "node server.mjs",
+    "tauri": "tauri",
+    "tauri:dev": "tauri dev",
+    "tauri:build": "tauri build"
+  },
   "dependencies": {
+    "@tauri-apps/api": "^2.0.0",
     "dotenv": "^17.2.2"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- reorder the package scripts to keep the tauri commands grouped and drop the redundant start alias
- promote the node engines block ahead of scripts for readability
- add @tauri-apps/api as a runtime dependency and refresh the lockfile entry

## Testing
- not run (manifest-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ca24cfce90832d949b27abe3147bba