### PR TITLE
fix(server): run dev api on port 3000

### DIFF
--- a/server/server.mjs
+++ b/server/server.mjs
@@ -23,7 +23,7 @@ aliasEnv("AIRTABLE_PAT", ["AIRTABLE_API_KEY"]);
 aliasEnv("AIRTABLE_BASE", ["AIRTABLE_BASE_ID"]);
 aliasEnv("AIRTABLE_TABLE", ["AIRTABLE_TABLE_NAME"]);
 
-const PORT = 8787;
+const PORT = 3000;
 let lastCanvasCourses = []; // [{id,name}]
 
 const headers = {


### PR DESCRIPTION
## Summary
- update the Node dev API server to listen on port 3000

## Migration Notes
- none required

## Rollback Plan
- revert this commit to restore the previous port

## Risks & Mitigations
- Low risk: only changes the listen port; ensure downstream tooling expects port 3000.

## Validation Plan / Test Matrix
- Not run (not requested).

## Desktop Smoke Test
- Not run for this change (server port update only).


------
https://chatgpt.com/codex/tasks/task_e_68ca26341a1c832d93532943598f9cb3