### PR TITLE
Use transcript helper when microphone access fails

### DIFF
--- a/index.html
+++ b/index.html
@@ -404,7 +404,7 @@
       source.connect(processor); processor.connect(audioCtx.destination);
       finalizeCurrentLine("Session started");
     }catch(e){
-      appendLineHTML("Mic denied/unavailable. Type notes while we sort it.");
+      finalizeCurrentLine("Mic denied/unavailable. Type notes while we sort it.");
       tag(stMic,"bad","Mic");
       running=false;
     }


### PR DESCRIPTION
## Summary
- call the existing `finalizeCurrentLine` helper when microphone access is denied so the transcript panel receives the friendly guidance line.

## Testing
- `node --input-type=module <<'NODE' ...` (Playwright script that stubs `getUserMedia` to reject and asserts the transcript shows the mic-denied message)


------
https://chatgpt.com/codex/tasks/task_e_68ca56e9f634832d8cef400d5ceb249d