### PR TITLE
Revamp ScribeCat dashboard and insights

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,9 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
-<title>ScribeCat v1.9.9</title>
-
-<!-- Google Fonts: 30-note menu (5 classic serif, 10 classic sans, 5 quirky serif, 10 quirky sans) -->
+<title>ScribeCat v2.0.0-preview</title>
 <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Merriweather:wght@400;700&family=Source+Serif+4:wght@400;700&family=IBM+Plex+Serif:wght@400;700&family=Crimson+Text:wght@400;700&family=Inter:wght@400;700&family=Roboto:wght@400;700&family=Open+Sans:wght@400;700&family=Noto+Sans:wght@400;700&family=IBM+Plex+Sans:wght@400;700&family=Source+Sans+3:wght@400;700&family=Manrope:wght@400;700&family=Work+Sans:wght@400;700&family=Fira+Sans:wght@400;700&family=Montserrat:wght@400;700&family=Poppins:wght@400;700&family=Raleway:wght@400;700&family=Outfit:wght@400;700&family=Space+Grotesk:wght@400;700&family=Playfair+Display:wght@400;700&family=Cinzel:wght@400;700&family=Alegreya:wght@400;700&family=Bodoni+Moda:wght@400;700&family=Cormorant+Garamond:wght@400;700&display=swap" rel="stylesheet"/>
-
 <style>
-  /* Title face: Galaxy Caterpillar (drop your file at web/fonts/GalaxyCaterpillar.ttf) */
   @font-face {
     font-family: "Galaxy Caterpillar";
     src: url("./fonts/GalaxyCaterpillar.ttf") format("truetype");
@@ -17,74 +13,172 @@
   }
 
   :root{
-    /* Base neutral theme (all others override these vars) */
     --bg:#f6f7fb; --surface:#ffffff; --ink:#101319; --sub:#6a7180; --border:#e3e7ef;
     --brand:#ffd200; --accent:#506fff; --accent-2:#ff5c8a;
     --btn:#ffffff; --btn-text:#111; --chip:#fff;
-
     --ok:#2eb450; --warn:#aa7a15; --bad:#e62e4d;
     --ui:Inter, system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,"Noto Sans";
     --notes:Inter, system-ui,-apple-system,"Segoe UI",Roboto,Helvetica,Arial,"Noto Sans";
+    --space-0:0; --space-1:4px; --space-2:8px; --space-3:12px; --space-4:16px; --space-5:20px; --space-6:24px;
+    --radius-sm:10px; --radius-md:16px; --radius-lg:22px;
+    --shadow-soft:0 12px 36px rgba(16,19,25,0.08);
   }
 
   *{box-sizing:border-box}
   html,body{height:100%}
-  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.45 var(--ui);overflow:hidden}
+  body{margin:0;background:var(--bg);color:var(--ink);font:15px/1.45 var(--ui);overflow:hidden;display:flex;flex-direction:column}
+  a{color:var(--accent)}
 
-  .container{max-width:1180px;margin:0 auto}
+  .container{width:min(1280px,100%);margin:0 auto;padding:0 16px}
 
-  /* Top bar */
   .topbar{background:var(--surface);border-bottom:1px solid var(--border)}
-  .topbar .inner{min-height:64px;display:flex;align-items:center;justify-content:space-between;padding:8px 16px;gap:12px}
+  .topbar .inner{min-height:64px;display:flex;align-items:center;justify-content:space-between;gap:16px;padding:8px 16px}
   .titlewrap{display:flex;align-items:center;gap:10px;min-width:0;flex:1}
   .nugget{width:48px;height:48px;object-fit:contain;flex:0 0 48px}
-  .title{font-family:"Galaxy Caterpillar", var(--ui);font-size:clamp(24px,5vw,44px);line-height:1;flex:1;white-space:nowrap;overflow:hidden}
+  .title{font-family:"Galaxy Caterpillar",var(--ui);font-size:clamp(24px,5vw,44px);line-height:1;flex:1;white-space:nowrap;overflow:hidden}
   .badge{padding:4px 10px;border:1px solid var(--border);border-radius:10px;font-size:13px;color:var(--sub);opacity:.85}
-  .status{display:flex;gap:6px;align-items:center;flex-wrap:wrap;max-width:44%}
-  .pill{border-radius:999px;padding:2px 8px;font-size:11px;border:1px solid var(--border);background:var(--chip);opacity:.72}
+  .status{display:flex;gap:6px;align-items:center;flex-wrap:wrap;justify-content:flex-end}
+  .pill{border-radius:999px;padding:4px 10px;font-size:12px;border:1px solid var(--border);background:var(--chip);opacity:.78;text-transform:uppercase;letter-spacing:.04em;font-weight:600}
   .ok{color:var(--ok)} .warn{color:var(--warn)} .bad{color:var(--bad)}
-  .chip{padding:6px 10px;border:1px solid var(--border);border-radius:12px;font-size:14px;background:var(--chip);display:inline-flex;gap:8px;align-items:center;color:var(--ink)}
+  .chip{padding:6px 10px;border:1px solid var(--border);border-radius:12px;font-size:14px;background:var(--chip);display:inline-flex;gap:8px;align-items:center;color:var(--ink);cursor:pointer}
   .chip.danger{background:var(--bad);border-color:var(--bad);color:#fff}
+  .chip.small{padding:4px 8px;font-size:12px}
 
-  /* Controls */
-  .controls{padding:10px 16px;display:grid;grid-template-columns:1fr auto;gap:8px;align-items:center}
+  .sessionbar{margin:16px auto 0;display:flex;flex-wrap:wrap;gap:16px;align-items:stretch}
+  .session-status{flex:1 1 280px;display:flex;gap:14px;align-items:flex-start;padding:16px 18px;background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);box-shadow:var(--shadow-soft);min-width:260px}
+  .session-status[data-tone="recording"]{border-color:rgba(230,46,77,0.3);box-shadow:0 8px 30px rgba(230,46,77,0.12)}
+  .session-status[data-tone="paused"]{border-color:rgba(80,111,255,0.35);box-shadow:0 10px 32px rgba(80,111,255,0.15)}
+  .session-pulse{width:14px;height:14px;border-radius:50%;background:var(--accent);flex-shrink:0;margin-top:4px;box-shadow:0 0 0 0 rgba(80,111,255,0.3);animation:pulse 1.6s infinite ease-in-out}
+  .session-status[data-tone="recording"] .session-pulse{background:var(--bad);box-shadow:0 0 0 0 rgba(230,46,77,0.25);animation:pulseHot 1s infinite}
+  .session-status[data-tone="paused"] .session-pulse{background:var(--warn);box-shadow:0 0 0 0 rgba(170,122,21,0.25);animation:pulseWarm 1.4s infinite}
+  .session-status[data-tone="ready"] .session-pulse{background:var(--accent)}
+  .session-status-text{display:flex;flex-direction:column;gap:6px;min-width:0}
+  .session-headline{font-size:18px;font-weight:600;line-height:1.35}
+  .session-subheadline{color:var(--sub);font-size:13px}
+  .session-next{font-size:13px;color:var(--accent);font-weight:600}
+
+  .session-metrics{flex:1 1 320px;display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px}
+  .metric-card{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-md);padding:14px 16px;display:flex;flex-direction:column;gap:8px;min-width:130px;position:relative;overflow:hidden}
+  .metric-card::after{content:"";position:absolute;inset:auto 0 0 0;height:3px;background:var(--accent);opacity:.8}
+  .metric-card.alert::after{background:var(--warn)}
+  .metric-value{font-size:22px;font-weight:700}
+  .metric-label{font-size:12px;color:var(--sub);text-transform:uppercase;letter-spacing:.05em}
+
+  .controls{padding:10px 16px;display:grid;grid-template-columns:1fr auto;gap:12px;align-items:center;margin-top:4px}
   .ctrl-row{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
-  .btn{padding:8px 12px;border:1px solid var(--border);border-radius:12px;background:var(--btn);color:var(--btn-text);cursor:pointer}
+  .btn{padding:8px 12px;border:1px solid var(--border);border-radius:12px;background:var(--btn);color:var(--btn-text);cursor:pointer;transition:transform .1s ease}
   .btn:active{transform:translateY(1px)}
-  select,input[type="text"]{height:36px;padding:6px 8px;border:1px solid var(--border);border-radius:10px;background:var(--surface);color:var(--ink)}
+  select,input[type="text"],input[type="search"],input[type="number"]{height:36px;padding:6px 10px;border:1px solid var(--border);border-radius:10px;background:var(--surface);color:var(--ink);font:14px/1.4 var(--ui)}
+  input[type="search"]{padding-inline-start:30px;background-image:url('data:image/svg+xml,%3Csvg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="%236a7180" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"%3E%3Ccircle cx="11" cy="11" r="7"/%3E%3Cline x1="20" y1="20" x2="16.65" y2="16.65"/%3E%3C/svg%3E');background-repeat:no-repeat;background-position:8px center}
   .vu{height:12px;background:#eaeaf3;border-radius:12px;overflow:hidden;min-width:160px;flex:1}
   .vu>div{height:100%;width:0;background:#2ee6a6;transition:width .08s}
 
-  /* Grid: side-by-side vs stacked (toggle in Settings) */
-  .grid{display:grid;grid-template-columns:1fr 1fr;gap:16px;padding:0 16px 24px;height:calc(100vh - 64px - 120px)}
-  body.stacked .grid{grid-template-columns:1fr}
+  .grid{display:grid;grid-template-columns:minmax(320px,1fr) minmax(360px,1.05fr) minmax(280px,0.9fr);gap:16px;padding:0 16px 24px;height:calc(100vh - 64px - 226px);overflow:hidden}
+  body.stacked .grid{grid-template-columns:1fr;height:auto;overflow:auto}
+  @media (max-width:1200px){.grid{grid-template-columns:minmax(320px,1fr) minmax(360px,1fr);height:calc(100vh - 64px - 246px)}}
+  @media (max-width:900px){.grid{grid-template-columns:1fr;height:auto;overflow:auto}}
 
-  .panel{background:var(--surface);border:1px solid var(--border);border-radius:16px;display:flex;flex-direction:column;min-height:0}
-  .panel .head{padding:12px 16px;border-bottom:1px solid var(--border);font-weight:600;display:flex;align-items:center;gap:10px}
-  .panel .body{padding:12px 16px;overflow:auto;min-height:0;overscroll-behavior:contain}
-  .footer{padding:10px 16px;border-top:1px solid var(--border);font-size:12px;color:var(--sub);display:flex;gap:8px;align-items:center}
+  .panel{background:var(--surface);border:1px solid var(--border);border-radius:var(--radius-lg);display:flex;flex-direction:column;min-height:0;overflow:hidden}
+  .panel .head{padding:14px 18px;border-bottom:1px solid var(--border);display:flex;align-items:flex-start;gap:12px;justify-content:space-between;flex-wrap:wrap}
+  .panel-title{font-weight:600;font-size:16px}
+  .panel-sub{font-size:12px;color:var(--sub)}
+  .panel .body{padding:16px 18px;overflow:auto;min-height:0;display:flex;flex-direction:column;gap:12px;overscroll-behavior:contain}
+  .panel .footer{padding:12px 18px;border-top:1px solid var(--border);font-size:12px;color:var(--sub);display:flex;gap:8px;align-items:center;justify-content:space-between;flex-wrap:wrap}
 
-  .notes{outline:none}
-  .toolbar{margin-left:auto;display:flex;flex-wrap:wrap;gap:8px;align-items:center}
-  .toolbar select,.toolbar input[type="number"]{height:30px}
+  .transcript-body{gap:10px}
+  .transcript-tools{display:flex;flex-wrap:wrap;gap:10px;align-items:center;justify-content:space-between}
+  .speaker-legend{display:flex;gap:8px;flex-wrap:wrap}
+  .speaker-chip{display:flex;align-items:center;gap:6px;font-size:12px;padding:6px 10px;border-radius:999px;background:rgba(80,111,255,0.08);border:1px solid rgba(80,111,255,0.18)}
+  .speaker-chip .dot{width:12px;height:12px;border-radius:50%}
+  .buffer-notice{display:none;align-items:center;gap:8px;background:rgba(80,111,255,0.1);border:1px dashed rgba(80,111,255,0.3);color:var(--accent);padding:8px 10px;border-radius:var(--radius-sm);font-size:13px}
+  .buffer-notice.show{display:flex}
+  .buffer-notice.warn{background:rgba(230,46,77,0.12);border-color:rgba(230,46,77,0.35);color:var(--bad)}
+  #streamConnectivity{color:var(--sub)}
 
-  /* Settings drawer */
-  .drawer{position:fixed;right:12px;top:76px;bottom:12px;width:460px;background:#f3f6ff;border:1px solid #dbe1ff;border-radius:14px;padding:10px 12px;overflow:auto;display:none;z-index:20}
-  .drawer .group{background:#fff;border:1px solid #dbe1ff;border-radius:10px;padding:10px;margin-bottom:10px}
+  #live{flex:1;overflow:auto;padding-right:6px;color:var(--ink);font-size:14px;line-height:1.5}
+  #live .line{padding:6px 4px;border-bottom:1px dotted transparent;display:grid;grid-template-columns:auto 1fr;gap:6px 10px;align-items:flex-start}
+  #live .line:last-child{border-bottom:none}
+  #live .line .ts{opacity:0;transition:opacity .15s ease;cursor:pointer;font-family:monospace;font-size:12px;color:var(--sub)}
+  #live .line:hover .ts{opacity:.65}
+  #live .line .speaker-label{display:flex;align-items:center;gap:6px;font-weight:600;font-size:13px;color:var(--ink)}
+  #live .line .speaker-badge{width:22px;height:22px;border-radius:50%;display:inline-flex;align-items:center;justify-content:center;font-size:11px;font-weight:600;color:#fff}
+  #live .line .line-text{font-size:14px;color:var(--ink)}
+  #live .line.partial .line-text{opacity:.8}
+  #live .line.finalized-pop{animation:highlightFade 1.4s ease}
+  #live .line.match{background:rgba(80,111,255,0.08);border-bottom-color:rgba(80,111,255,0.18)}
+  #live .line.system .speaker-label{color:var(--sub)}
+
+  .notes{outline:none;font-family:var(--notes);line-height:1.55;font-size:16px}
+  .notes p{margin:0 0 10px}
+  .notes h1,.notes h2,.notes h3,.notes h4{margin:16px 0 8px}
+  .notes ul,.notes ol{margin:0 0 12px 20px}
+  .notes .callout{border-radius:var(--radius-md);padding:12px 14px;border:1px solid rgba(80,111,255,0.25);background:rgba(80,111,255,0.08);margin:8px 0}
+  .notes .callout.danger{border-color:rgba(230,46,77,0.35);background:rgba(230,46,77,0.08)}
+  .notes table{border-collapse:collapse;width:100%;margin:12px 0;font-size:14px}
+  .notes th,.notes td{border:1px solid var(--border);padding:8px;text-align:left}
+  .todo-list{list-style:none;padding:0;margin:0 0 10px}
+  .todo-list li{margin-bottom:6px;display:flex;gap:8px;align-items:flex-start}
+  .todo-list input[type="checkbox"]{margin-top:4px}
+  details.note-section{border:1px solid var(--border);border-radius:var(--radius-md);padding:0;margin:10px 0;background:rgba(16,19,25,0.02)}
+  details.note-section[open]{background:rgba(80,111,255,0.06)}
+  details.note-section summary{cursor:pointer;list-style:none;padding:10px 14px;font-weight:600;outline:none}
+  details.note-section summary::-webkit-details-marker{display:none}
+  details.note-section summary[contenteditable="true"]:focus{outline:1px solid var(--accent)}
+  details.note-section .note-section-body{padding:10px 14px 14px}
+  .note-match{box-shadow:0 0 0 2px rgba(80,111,255,0.25);border-radius:8px}
+  .note-bookmark{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;background:rgba(80,111,255,0.1);border:1px dashed rgba(80,111,255,0.3);font-size:12px;margin:4px 0}
+
+  .notes-toolbar{display:flex;flex-wrap:wrap;gap:8px;align-items:center}
+  .notes-toolbar .group{display:flex;gap:6px;align-items:center}
+  .note-search{display:flex;align-items:center;gap:8px;margin-left:auto}
+  #quickJumpList{display:flex;flex-wrap:wrap;gap:6px;margin:-4px 0 4px}
+  #quickJumpList button{border:1px solid var(--border);background:var(--chip);border-radius:999px;padding:4px 10px;font-size:12px;cursor:pointer}
+
+  .insights{flex:1;display:flex;flex-direction:column;gap:18px;min-height:0}
+  .insights section h5{margin:0 0 8px;font-size:13px;text-transform:uppercase;letter-spacing:.05em;color:var(--sub)}
+  .insight-empty{color:var(--sub);font-size:13px}
+  .insight-list,.pinned-list,.review-list,.activity-log{display:flex;flex-direction:column;gap:10px}
+  .insight-card,.review-card,.pinned-card{border:1px solid var(--border);border-radius:var(--radius-md);padding:12px 14px;background:rgba(16,19,25,0.01)}
+  .insight-card h4{margin:0 0 6px;font-size:15px}
+  .insight-card .meta{font-size:12px;color:var(--sub);margin-bottom:6px}
+  .insight-card .actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px}
+  .insight-card button,.review-card button,.pinned-card button{padding:6px 10px;border-radius:10px;border:1px solid var(--border);background:var(--chip);cursor:pointer;font-size:13px}
+  .pinned-card .meta{font-size:12px;color:var(--sub);margin-top:6px}
+  .review-card{border-left:3px solid var(--warn);background:rgba(170,122,21,0.08)}
+  .review-card .meta{font-size:12px;color:var(--sub)}
+  .activity-log{max-height:220px;overflow:auto}
+  .log-entry{display:grid;grid-template-columns:auto auto 1fr;gap:8px 12px;font-size:12px;padding:6px;border-radius:10px;border:1px solid transparent;background:rgba(16,19,25,0.02)}
+  .log-entry:nth-child(odd){background:rgba(16,19,25,0.04)}
+  .log-entry .log-time{font-family:monospace;color:var(--sub)}
+  .log-entry .log-type{font-weight:600;text-transform:uppercase;letter-spacing:.05em}
+  .log-entry .log-data{grid-column:1/-1;background:rgba(16,19,25,0.04);padding:6px;border-radius:8px;font-family:monospace;white-space:pre-wrap}
+
+  .privacy-foot{width:100%;display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap}
+  .privacy-foot .foot-actions{display:flex;gap:8px}
+
+  .drawer{position:fixed;right:12px;top:76px;bottom:12px;width:480px;background:#f3f6ff;border:1px solid #dbe1ff;border-radius:18px;padding:14px 16px;overflow:auto;display:none;z-index:20;box-shadow:0 18px 50px rgba(16,19,25,0.18)}
+  .drawer .group{background:#fff;border:1px solid #dbe1ff;border-radius:14px;padding:12px 14px;margin-bottom:12px}
+  .drawer .group h4{margin:0 0 6px}
   .sub{color:#6a7180;font-size:12px}
 
-  /* Version at bottom */
   .ver{position:fixed;left:12px;bottom:8px;font-size:12px;color:#77819a;opacity:.85}
+  .theme-warning{position:fixed;right:12px;bottom:8px;font-size:12px;color:#fff;background:#e62e4d;padding:6px 10px;border-radius:10px;display:none;z-index:30}
 
-  /* Contrast helpers */
-  .theme-warning{position:fixed;right:12px;bottom:8px;font-size:12px;color:#fff;background:#e62e4d;padding:6px 10px;border-radius:10px;display:none}
-/* Hover-only timestamps in transcript */
-#live .line .ts{opacity:0;transition:opacity .15s ease;cursor:pointer}
-#live .line:hover .ts{opacity:.65}
+  .footbar{position:fixed;right:12px;bottom:8px;display:flex;gap:8px;align-items:center;z-index:25}
+  .footbtn{padding:6px 8px;border:1px solid var(--border);border-radius:10px;background:var(--chip);cursor:pointer;font-size:14px}
 
-/* Bottom footer bar */
-.footbar{position:fixed;right:12px;bottom:8px;display:flex;gap:8px;align-items:center;z-index:25}
-.footbtn{padding:6px 8px;border:1px solid var(--border);border-radius:10px;background:var(--chip);cursor:pointer;font-size:14px}
+  @keyframes pulse{0%{box-shadow:0 0 0 0 rgba(80,111,255,0.3)}100%{box-shadow:0 0 0 14px rgba(80,111,255,0)}}
+  @keyframes pulseHot{0%{box-shadow:0 0 0 0 rgba(230,46,77,0.28)}100%{box-shadow:0 0 0 12px rgba(230,46,77,0)}}
+  @keyframes pulseWarm{0%{box-shadow:0 0 0 0 rgba(170,122,21,0.25)}100%{box-shadow:0 0 0 14px rgba(170,122,21,0)}}
+  @keyframes highlightFade{0%{background:rgba(80,111,255,0.18)}100%{background:transparent}}
+
+  @media (max-width:720px){
+    .controls{grid-template-columns:1fr}
+    .note-search{width:100%;justify-content:flex-start;margin-left:0}
+    .sessionbar{flex-direction:column}
+    .session-status,.session-metrics{width:100%}
+    .drawer{width:calc(100% - 24px)}
+  }
 </style>
 </head>
 <body>
@@ -104,6 +198,35 @@
   </div>
 </div>
 
+<div class="sessionbar container">
+  <div id="sessionStatus" class="session-status" data-tone="ready">
+    <div id="sessionPulse" class="session-pulse"></div>
+    <div class="session-status-text">
+      <div id="sessionHeadline" class="session-headline">Ready to capture brilliant lectures.</div>
+      <div id="sessionSubheadline" class="session-subheadline">Check mic & API before starting.</div>
+      <div id="sessionNextAction" class="session-next">Next action: Press Start.</div>
+    </div>
+  </div>
+  <div class="session-metrics">
+    <div class="metric-card" id="metricDurationCard">
+      <div id="metricDuration" class="metric-value">00:00</div>
+      <div class="metric-label">Duration</div>
+    </div>
+    <div class="metric-card" id="metricSegmentsCard">
+      <div id="metricSegments" class="metric-value">0</div>
+      <div class="metric-label">Transcript entries</div>
+    </div>
+    <div class="metric-card" id="metricSpeakersCard">
+      <div id="metricSpeakers" class="metric-value">1</div>
+      <div class="metric-label">Speakers tracked</div>
+    </div>
+    <div class="metric-card" id="metricHighlightsCard">
+      <div id="metricHighlights" class="metric-value">0</div>
+      <div class="metric-label">Pinned insights</div>
+    </div>
+  </div>
+</div>
+
 <div class="controls container">
   <div class="ctrl-row">
     <select id="classSel" title="Class"></select>
@@ -113,10 +236,10 @@
     <div class="vu"><div id="vuBar"></div></div>
   </div>
   <div class="ctrl-row" style="justify-self:end">
-    <button id="startBtn"  class="btn">▶ Start</button>
-    <button id="pauseBtn"  class="btn" style="display:none">Pause</button>
+    <button id="startBtn" class="btn">▶ Start</button>
+    <button id="pauseBtn" class="btn" style="display:none">Pause</button>
     <button id="resumeBtn" class="btn" style="display:none">Resume</button>
-    <button id="stopBtn"   class="btn" style="display:none">⏹ Stop</button>
+    <button id="stopBtn" class="btn" style="display:none">⏹ Stop</button>
     <button id="summaryBtn" class="btn" style="display:none">Summarize → Notes</button>
     <button id="saveBtn" class="btn" style="background:var(--accent);color:#fff;border-color:transparent">Save</button>
   </div>
@@ -125,39 +248,116 @@
 <div class="grid container">
   <div class="panel">
     <div class="head">
-      <div>Live Transcript</div>
-      <label class="chip"><input id="sentenceChk" type="checkbox" checked/> sentence</label>
-      <label class="chip"><input id="tsChk" type="checkbox" checked/> timestamps</label>
+      <div>
+        <div class="panel-title">Live Transcript</div>
+        <div class="panel-sub">Streaming from AssemblyAI</div>
+      </div>
+      <div class="panel-actions" style="display:flex;flex-wrap:wrap;gap:8px;align-items:center">
+        <input id="transcriptSearchInput" type="search" placeholder="Search transcript"/>
+        <button id="refreshTranscriptBtn" class="btn" title="Reconnect transcript">↻ Refresh</button>
+      </div>
     </div>
-    <div id="live" class="body" style="color:var(--ink);font-size:14px;line-height:1.45"></div>
+    <div class="body transcript-body">
+      <div class="transcript-tools">
+        <div id="transcriptLegend" class="speaker-legend"></div>
+        <div id="bufferNotice" class="buffer-notice">Buffering AssemblyAI…</div>
+      </div>
+      <div id="live"></div>
+    </div>
     <div class="footer">
-      <label><input id="autoScrollChk" type="checkbox" checked/> Auto-scroll</label>
-      <span class="sub">(Scroll up to pause; resume near bottom)</span>
+      <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+        <label><input id="sentenceChk" type="checkbox" checked/> Sentence mode</label>
+        <label><input id="tsChk" type="checkbox" checked/> Timestamps</label>
+        <label><input id="autoScrollChk" type="checkbox" checked/> Auto-scroll</label>
+      </div>
+      <span id="streamConnectivity">Streaming idle.</span>
     </div>
   </div>
 
   <div class="panel">
     <div class="head">
-      <div>Notes</div>
-      <div class="toolbar">
-        <div><select id="fontSizeSel" title="Font size"></select><input id="fontSizeBox" type="number" min="4" max="60" value="16" title="Font size (type)"/></div>
-        <select id="fontFamilySel" title="Font family (selection)"></select>
-        <div id="colorTools" style="display:flex;gap:6px;align-items:center">
+      <div>
+        <div class="panel-title">Notes</div>
+        <div class="panel-sub">Google Docs–style shortcuts + power tools</div>
+      </div>
+      <div class="notes-toolbar">
+        <div class="group"><select id="fontSizeSel" title="Font size"></select><input id="fontSizeBox" type="number" min="4" max="60" value="16" title="Font size (type)"/></div>
+        <select id="fontFamilySel" title="Font family"></select>
+        <div class="group" id="colorTools">
           <button id="fontColorBtn" class="btn" title="Font color">A</button>
           <input id="fontColor" type="color" style="width:0;height:0;border:0;padding:0;opacity:0"/>
           <button id="hlBtn" class="btn" title="Highlighter">🖍️</button>
           <input id="hlColor" type="color" value="#ffd200" style="width:0;height:0;border:0;padding:0;opacity:0"/>
           <input id="hexBox" placeholder="#hex" style="width:80px;height:30px;border:1px solid var(--border);border-radius:8px;padding:0 6px"/>
+          <button id="unhlBtn" class="btn" title="Clear inline styles">🧽</button>
         </div>
-        <button id="unhlBtn" class="btn" title="Clear inline styles">🧽</button>
-        <button id="boldBtn" class="btn" title="Bold (⌘/Ctrl+B)">B</button>
-        <button id="italicBtn" class="btn" title="Italic (⌘/Ctrl+I)" style="font-style:italic">I</button>
-        <button id="undoBtn" class="btn" title="Undo">↶</button>
-        <button id="redoBtn" class="btn" title="Redo">↷</button>
+        <div class="group">
+          <button id="boldBtn" class="btn" title="Bold (⌘/Ctrl+B)">B</button>
+          <button id="italicBtn" class="btn" title="Italic (⌘/Ctrl+I)" style="font-style:italic">I</button>
+          <button id="undoBtn" class="btn" title="Undo">↶</button>
+          <button id="redoBtn" class="btn" title="Redo">↷</button>
+        </div>
+        <div class="group">
+          <button id="insertSectionBtn" class="btn" title="Collapsible section">Section</button>
+          <button id="insertBookmarkBtn" class="btn" title="Bookmark location">Bookmark</button>
+          <button id="insertCalloutBtn" class="btn" title="Callout block">Callout</button>
+          <button id="insertTableBtn" class="btn" title="2×2 table">Table</button>
+          <button id="insertTodoBtn" class="btn" title="Checklist">Checklist</button>
+        </div>
+        <div class="note-search">
+          <input id="noteSearchInput" type="search" placeholder="Search notes" style="min-width:180px"/>
+        </div>
       </div>
     </div>
-    <div id="notes" class="body notes" contenteditable="true">
-      <p>• Welcome back. Shortcuts on: Cmd/Ctrl-Shift-8 bullets, Cmd/Ctrl-Shift-7 numbers, Cmd-Shift-- em dash —, Cmd-Shift-. arrow →, Cmd+M timestamp marker.</p>
+    <div class="body">
+      <div id="quickJumpList"></div>
+      <div id="notes" class="notes" contenteditable="true">
+        <p>• Welcome back. Shortcuts on: Cmd/Ctrl-Shift-8 bullets, Cmd/Ctrl-Shift-7 numbers, Cmd-Shift-- em dash —, Cmd-Shift-. arrow →, Cmd+M timestamp marker.</p>
+      </div>
+    </div>
+    <div class="footer">
+      <span>Need inspiration? Generate an AI summary then pin highlights into your notes.</span>
+      <span class="sub">Notes stay local unless you save.</span>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="head">
+      <div>
+        <div class="panel-title">Insights &amp; Privacy</div>
+        <div class="panel-sub">Real-time intelligence, review queue, and audit trail</div>
+      </div>
+      <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+        <button id="generateInsightBtn" class="btn">AI summarize</button>
+        <label class="chip small"><input type="checkbox" id="includeContextChk" checked/> Include notes</label>
+      </div>
+    </div>
+    <div class="body insights">
+      <section>
+        <h5>AI summaries</h5>
+        <div id="insightList" class="insight-list"></div>
+        <div id="insightEmpty" class="insight-empty">Select transcript text or leave blank to summarize the whole session.</div>
+      </section>
+      <section>
+        <h5>Pinned to notes</h5>
+        <div id="pinnedSummaries" class="pinned-list"></div>
+      </section>
+      <section>
+        <h5>Review queue</h5>
+        <div id="reviewList" class="review-list"></div>
+      </section>
+      <section>
+        <h5>Activity log <button id="toggleLogDetailsBtn" class="chip small">Show details</button></h5>
+        <div id="activityLog" class="activity-log"></div>
+      </section>
+    </div>
+    <div class="footer">
+      <div class="privacy-foot">
+        <span id="privacyStatus">Privacy defaults applied.</span>
+        <div class="foot-actions">
+          <button id="downloadPrivacyReportBtn" class="btn">Download privacy report</button>
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -186,12 +386,37 @@
   </div>
 
   <div class="group">
+    <h4>Privacy controls</h4>
+    <label><input type="checkbox" id="privacyStoreTranscript" checked> Include transcript text when saving</label><br/>
+    <label><input type="checkbox" id="privacyStoreAudio" checked> Upload audio to the server when saving</label><br/>
+    <label><input type="checkbox" id="privacyLocalNotes" checked> Keep notes locally after stop</label><br/>
+    <label>Auto-delete session data after
+      <select id="privacyAutoDelete">
+        <option value="0">Never</option>
+        <option value="5">5 minutes</option>
+        <option value="15">15 minutes</option>
+        <option value="30">30 minutes</option>
+        <option value="60">60 minutes</option>
+      </select>
+    </label>
+    <div style="margin-top:8px;display:flex;gap:8px;flex-wrap:wrap">
+      <button id="privacyNukeBtn" class="btn" style="background:#ffe3e3;border-color:#ffb3b3">Clear session data now</button>
+    </div>
+  </div>
+
+  <div class="group">
+    <h4>Environment diagnostics</h4>
+    <button id="envCheckBtn" class="btn">Check configured services</button>
+    <div id="envCheckResults" class="sub" style="margin-top:8px"></div>
+  </div>
+
+  <div class="group">
     <h4>Canvas bookmarklet</h4>
     <div class="sub" style="margin-bottom:8px">
       1) Drag the button below to your bookmarks bar. 2) Go to your Canvas Dashboard (the page that shows all courses). 3) Click the bookmark—ScribeCat will open and import the course names automatically (we de-dupe and strip codes).
     </div>
     <a class="btn" style="background:var(--accent);color:#fff;border-color:transparent"
-       href="javascript:(function(){try{const sel=(...qs)=>qs.flatMap(q=>[...document.querySelectorAll(q)]);const texts=sel('[data-automation=dashboardCard__link]','.ic-DashboardCard__header-title','a.ig-title','.context_list_context a').map(a=>a.textContent.trim()).filter(Boolean);const uniq=[...new Set(texts)];const cleaned=uniq.map(t=>t.replace(/\\b\\d{2}F-[A-Z]+\\d{3,}-\\d{3}\\d{4}\\b.*$/,'').replace(/\\b25F-[A-Z]+\\d{3,}-\\d{3}\\b.*$/,'').replace(/\\s*—\\s*/g,' — ').replace(/\\s{2,}/g,' ').trim()).filter(Boolean);const url=location.origin+location.pathname+'#classes='+encodeURIComponent(JSON.stringify(cleaned));window.open(url,'_blank');}catch(e){alert('ScribeCat bookmarklet error: '+e.message)}})()">Add courses to ScribeCat</a>
+       href="javascript:(function(){try{const sel=(...qs)=>qs.flatMap(q=>[...document.querySelectorAll(q)]);const texts=sel('[data-automation=dashboardCard__link]','.ic-DashboardCard__header-title','a.ig-title','.context_list_context a').map(a=>a.textContent.trim()).filter(Boolean);const uniq=[...new Set(texts)];const cleaned=uniq.map(t=>t.replace(/\b\d{2}F-[A-Z]+\d{3,}-\d{3}\d{4}\b.*$/,'').replace(/\b25F-[A-Z]+\d{3,}-\d{3}\b.*$/,'').replace(/\s*—\s*/g,' — ').replace(/\s{2,}/g,' ').trim()).filter(Boolean);const url=location.origin+location.pathname+'#classes='+encodeURIComponent(JSON.stringify(cleaned));window.open(url,'_blank');}catch(e){alert('ScribeCat bookmarklet error: '+e.message)}})()">Add courses to ScribeCat</a>
   </div>
 
   <div class="group">
@@ -200,9 +425,9 @@
   </div>
 </div>
 
-<div class="ver">ScribeCat v1.9.9</div>
+<div class="ver">ScribeCat v2.0.0-preview</div>
 <div class="footbar">
-  <button id="layoutBtn" class="footbtn" title="Toggle layout (stacked / side-by-side)">🧩</button>
+  <button id="layoutBtn" class="footbtn" title="Toggle layout (stacked / adaptive)">🧩</button>
 </div>
 <div id="contrastWarn" class="theme-warning">Adjusted for contrast</div>
 
@@ -210,443 +435,794 @@
 (function(){
   const API = "http://127.0.0.1:8787";
   const $ = s => document.querySelector(s), byId = id => document.getElementById(id);
-  const stApi=byId("stApi"), stMic=byId("stMic"), stStream=byId("stStream");
-  const classSel=byId("classSel"), titleBox=byId("titleBox");
-  const micSel=byId("micSel"), vu=byId("vuBar");
-  const startBtn=byId("startBtn"), pauseBtn=byId("pauseBtn"), resumeBtn=byId("resumeBtn"), stopBtn=byId("stopBtn");
-  const saveBtn=byId("saveBtn"), summaryBtn=byId("summaryBtn");
-  const live=byId("live"), notes=byId("notes");
-  const autoScroll=byId("autoScrollChk"), tsChk=byId("tsChk"), sentenceChk=byId("sentenceChk");
-  const gearBtn=byId("gearBtn"), drawer=byId("drawer"), manageBtn=byId("manageBtn");
-  const quitDrawerBtn=byId("quitBtn"), quitTopBtn=byId("quitBtnTop");
-  const stackedToggle=byId("stackedToggle");
-  const themeSel=byId("themeSel"), applyTheme=byId("applyTheme");
-  const b_sentence=byId("b_sentence"), b_autoretry=byId("b_autoretry"), b_markers=byId("b_markers"), b_autoscroll=byId("b_autoscroll"), b_timestamps=byId("b_timestamps"), b_autopolish=byId("b_autopolish");
 
-  function tag(el, state, text){ el.classList.remove("ok","warn","bad"); el.classList.add(state); el.textContent=text; }
-  fetch(API+"/").then(r=>tag(stApi, r.ok?"ok":"bad", r.ok?"API":"API")).catch(()=>tag(stApi,"bad","API"));
-  gearBtn.onclick = ()=> drawer.style.display = (drawer.style.display==='none'||!drawer.style.display)?'block':'none';
-  manageBtn.onclick = ()=> drawer.style.display='block';
-  stackedToggle.onchange = ()=> document.body.classList.toggle('stacked', stackedToggle.checked);
+  const dom = {
+    status:{ api:byId("stApi"), mic:byId("stMic"), stream:byId("stStream") },
+    header:{ wrap:byId("sessionStatus"), pulse:byId("sessionPulse"), headline:byId("sessionHeadline"), sub:byId("sessionSubheadline"), next:byId("sessionNextAction") },
+    metrics:{ duration:byId("metricDuration"), segments:byId("metricSegments"), speakers:byId("metricSpeakers"), highlights:byId("metricHighlights"), durationCard:byId("metricDurationCard"), segmentsCard:byId("metricSegmentsCard") },
+    controls:{ classSel:byId("classSel"), manage:byId("manageBtn"), title:byId("titleBox"), micSel:byId("micSel"), vu:byId("vuBar"), start:byId("startBtn"), pause:byId("pauseBtn"), resume:byId("resumeBtn"), stop:byId("stopBtn"), summary:byId("summaryBtn"), save:byId("saveBtn") },
+    transcript:{ container:byId("live"), sentence:byId("sentenceChk"), timestamps:byId("tsChk"), autoScroll:byId("autoScrollChk"), legend:byId("transcriptLegend"), search:byId("transcriptSearchInput"), refresh:byId("refreshTranscriptBtn"), buffer:byId("bufferNotice"), connectivity:byId("streamConnectivity") },
+    notes:{ root:byId("notes"), fontSizeSel:byId("fontSizeSel"), fontSizeBox:byId("fontSizeBox"), fontFamilySel:byId("fontFamilySel"), fontColorBtn:byId("fontColorBtn"), fontColor:byId("fontColor"), hlBtn:byId("hlBtn"), hlColor:byId("hlColor"), hexBox:byId("hexBox"), unhl:byId("unhlBtn"), bold:byId("boldBtn"), italic:byId("italicBtn"), undo:byId("undoBtn"), redo:byId("redoBtn"), insertSection:byId("insertSectionBtn"), insertBookmark:byId("insertBookmarkBtn"), insertCallout:byId("insertCalloutBtn"), insertTable:byId("insertTableBtn"), insertTodo:byId("insertTodoBtn"), search:byId("noteSearchInput"), quickJump:byId("quickJumpList") },
+    insights:{ generate:byId("generateInsightBtn"), includeNotes:byId("includeContextChk"), list:byId("insightList"), empty:byId("insightEmpty"), pinned:byId("pinnedSummaries") },
+    review:{ list:byId("reviewList") },
+    activity:{ list:byId("activityLog"), toggle:byId("toggleLogDetailsBtn") },
+    privacy:{ status:byId("privacyStatus"), storeTranscript:byId("privacyStoreTranscript"), storeAudio:byId("privacyStoreAudio"), keepLocalNotes:byId("privacyLocalNotes"), autoDelete:byId("privacyAutoDelete"), nuke:byId("privacyNukeBtn") },
+    theme:{ select:byId("themeSel"), apply:byId("applyTheme"), warning:byId("contrastWarn") },
+    drawer:byId("drawer"),
+    layout:{ stacked:byId("stackedToggle"), quick:byId("layoutBtn") },
+    env:{ button:byId("envCheckBtn"), results:byId("envCheckResults") },
+    gear:byId("gearBtn"), manageBtn:byId("manageBtn"), quitDrawer:byId("quitBtn"), quitTop:byId("quitBtnTop")
+  };
 
-  /* ======== THEMES (with contrast-safe colors across UI) ======== */
-  const THEMES = {
-  "Clean":      {bg:'#f6f7fb',surface:'#fff',ink:'#101319',sub:'#6a7180',border:'#e3e7ef',brand:'#ffd200',accent:'#506fff',accent2:'#ff5c8a',btn:'#fff',btnText:'#111'},
-  "Dark Ink":   {bg:'#0f1115',surface:'#161a22',ink:'#f1f5f9',sub:'#93a4b3',border:'#232b3a',brand:'#ffd200',accent:'#8aa9ff',accent2:'#ff95b2',btn:'#1f2532',btnText:'#fff'},
-  "Slate Pop":  {bg:'#f2f5f7',surface:'#ffffff',ink:'#1c212b',sub:'#5f6e80',border:'#d7e0e9',brand:'#ffd200',accent:'#ff5c8a',accent2:'#2e6aff',btn:'#fff',btnText:'#111'},
-  "Ocean":      {bg:'#e9f1f7',surface:'#ffffff',ink:'#0b2239',sub:'#4d6174',border:'#d2e0eb',brand:'#ffd200',accent:'#2e6aff',accent2:'#0ea5e9',btn:'#fff',btnText:'#0b2239'},
-  "Paper":      {bg:'#fbfbf7',surface:'#fff',ink:'#111',sub:'#666',border:'#ecebe6',brand:'#ffd200',accent:'#2f6fff',accent2:'#c2410c',btn:'#fff',btnText:'#111'},
-  "Plum":       {bg:'#f7f4fa',surface:'#fff',ink:'#201226',sub:'#6c5a76',border:'#e8e1ee',brand:'#ffd200',accent:'#7b3eff',accent2:'#ff5ea8',btn:'#fff',btnText:'#201226'},
-  "Forest":     {bg:'#f2f7f4',surface:'#fff',ink:'#0c2116',sub:'#476453',border:'#d9e7df',brand:'#ffd200',accent:'#1f8a6f',accent2:'#3b82f6',btn:'#fff',btnText:'#0c2116'},
-  "Charcoal":   {bg:'#15181d',surface:'#1b2027',ink:'#f2f4f8',sub:'#97a3b0',border:'#28303a',brand:'#ffd200',accent:'#7aa2ff',accent2:'#ff8fb0',btn:'#242b35',btnText:'#f2f4f8'},
-  "Citrus":     {bg:'#fffdf6',surface:'#ffffff',ink:'#1f1407',sub:'#6b5a44',border:'#efe7d6',brand:'#ffd200',accent:'#ff7d26',accent2:'#0ea5e9',btn:'#fff',btnText:'#1f1407'},
-  "Neon Night": {bg:'#0b0e18',surface:'#101425',ink:'#eaf1ff',sub:'#9fb0c9',border:'#1a2140',brand:'#ffd200',accent:'#4be9b9',accent2:'#a78bfa',btn:'#16203a',btnText:'#eaf1ff'},
-  "Rose Slate": {bg:'#f9f4f6',surface:'#ffffff',ink:'#28151b',sub:'#6d545f',border:'#ecdbe1',brand:'#ffd200',accent:'#ff5c8a',accent2:'#7c3aed',btn:'#fff',btnText:'#28151b'},
-  "High Noon":  {bg:'#fff8e6',surface:'#ffffff',ink:'#2b1a00',sub:'#7a5a2b',border:'#f1e4c7',brand:'#ffd200',accent:'#d97706',accent2:'#2563eb',btn:'#fff',btnText:'#2b1a00'}
-};
-  themeSel.innerHTML = Object.keys(THEMES).map(n=>`<option>${n}</option>`).join("");
-  function applyThemeVars(t){
-    const r=document.documentElement.style;
-    const warn=$("#contrastWarn");
-    const pairs=[[t.surface,t.ink],[t.bg,t.ink],[t.btn,t.btnText]];
-    let needsWarn=false;
-    function ratio(hex1,hex2){
-      function lum(h){const c=parseInt(h.slice(1),16);const r=(c>>16)&255,g=(c>>8)&255,b=c&255;const a=[r,g,b].map(v=>{v/=255;return v<=0.03928?v/12.92:Math.pow((v+0.055)/1.055,2.4)});return 0.2126*a[0]+0.7152*a[1]+0.0722*a[2];}
-      const L1=lum(hex1),L2=lum(hex2); const R=(Math.max(L1,L2)+0.05)/(Math.min(L1,L2)+0.05); return R;
-    }
-    pairs.forEach(([bg,fg])=>{ try{ if(ratio(bg,fg)<4.5) needsWarn=true; }catch{} });
-    ["--bg","--surface","--ink","--sub","--border","--brand","--accent","--accent-2","--btn","--btn-text"]
-      .forEach(()=>{});
-    r.setProperty('--bg',t.bg); r.setProperty('--surface',t.surface); r.setProperty('--ink',t.ink);
-    r.setProperty('--sub',t.sub); r.setProperty('--border',t.border); r.setProperty('--brand',t.brand);
-    r.setProperty('--accent',t.accent); r.setProperty('--accent-2',t.accent2);
-    r.setProperty('--btn',t.btn); r.setProperty('--btn-text',t.btnText);
-    warn.style.display = needsWarn ? 'block' : 'none';
-  }
-  applyThemeVars(THEMES["Clean"]);
-  applyTheme.onclick = ()=> applyThemeVars(THEMES[themeSel.value]||THEMES["Clean"]);
+  const behaviorControls = {
+    sentence:byId("b_sentence"),
+    autoretry:byId("b_autoretry"),
+    markers:byId("b_markers"),
+    autoscroll:byId("b_autoscroll"),
+    timestamps:byId("b_timestamps"),
+    autopolish:byId("b_autopolish")
+  };
 
-  /* ======== MIC/STREAM/TRANSCRIPT ======== */
-  let running=false, paused=false, startTs=null, ws=null;
-  let audioCtx, source, processor, mediaStream;
-  let userNearBottom=true, sentBuf="", transcriptText="";
-  let wavChunks=[], wavSampleRate=44100, audioBlob=null, lineCounter=0, lastLineId=null, currentLineEl=null;
+  const storage = {
+    get(key, fallback){ try{ const raw = localStorage.getItem(key); return raw ? JSON.parse(raw) : fallback; }catch{return fallback;} },
+    set(key, value){ try{ localStorage.setItem(key, JSON.stringify(value)); }catch{} }
+  };
 
+  const state = {
+    running:false,
+    paused:false,
+    startTs:null,
+    audioCtx:null,
+    source:null,
+    processor:null,
+    mediaStream:null,
+    ws:null,
+    wavChunks:[],
+    wavSampleRate:44100,
+    audioBlob:null,
+    lineCounter:0,
+    userNearBottom:true,
+    autoDeleteTimer:null,
+    connectivityTimer:null,
+    clockTimer:null,
+    lastMessageAt:0,
+    envStatus:null
+  };
+
+  const transcriptState = {
+    segments:[],
+    liveSegment:null,
+    reviewQueue:[],
+    flagged:new Set(),
+    speakerColors:new Map(),
+    colorPalette:['#4F46E5','#F97316','#0EA5E9','#10B981','#F43F5E','#8B5CF6','#14B8A6','#EC4899','#6366F1','#22D3EE'],
+    colorIndex:0
+  };
+
+  const insightsState = { items:[], pinned:[] };
+  const activityLog = [];
+  let revealLogDetails = false;
+
+  let behaviorPrefs = storage.get('lc_behaviors_v2', { sentence:true, autoretry:true, markers:true, autoscroll:true, timestamps:true, autopolish:true });
+  let privacyPrefs = storage.get('lc_privacy_v1', { storeTranscript:true, storeAudio:true, keepLocalNotes:true, autoDeleteMinutes:0 });
+  let layoutPrefs = storage.get('lc_layout_v1', { stacked:false });
+  let themePref = storage.get('lc_theme_v2', 'Clean');
+
+  const speakerSystem = 'System';
+
+  function clamp(v,a,b){return Math.max(a,Math.min(b,v));}
+  function escapeHtml(str){return String(str).replace(/[&<>"']/g,s=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#39;"}[s]||s));}
   function nearBottom(el,px=48){ return (el.scrollHeight - el.scrollTop - el.clientHeight) <= px; }
-  live.addEventListener("scroll",()=>{ userNearBottom = nearBottom(live); }, {passive:true});
-  function clock(){ const t=new Date(); return [t.getHours(),t.getMinutes(),t.getSeconds()].map(v=>String(v).padStart(2,'0')).join(':'); }
-  function mmss(){ const tsec=((Date.now()-(startTs||Date.now()))/1000)|0; const mm=String((tsec/60)|0).padStart(2,"0"), ss=String(tsec%60).padStart(2,"0"); return `${mm}:${ss}`; }window.mmss = mmss;
-  function makeTimestampSpan(){
-  const tsOn = (tsChk.checked || b_timestamps.checked);
-  return tsOn ? `<span class="ts">[${mmss()}]</span> ` : '';
-}
-  function makeLine(html, isLive){
-    const id = `t-${mmss().replace(':','')}-${(++lineCounter)}`;
-    const div = document.createElement('div');
-    div.className = isLive ? 'line liveLine' : 'line';
-    div.id = id;
-    div.innerHTML = makeTimestampSpan() + html;
-    live.appendChild(div);
-    if (!isLive){
-      lastLineId = id;
-      window.lastLineId = id;
-    }
-    if ((autoScroll.checked && b_autoscroll.checked) && userNearBottom) live.scrollTop = live.scrollHeight;
-    return div;
-  }
-  function setCurrentLineText(html){
-    if (!currentLineEl){ currentLineEl = makeLine(html, true); return; }
-    currentLineEl.innerHTML = makeTimestampSpan() + html;
-    if ((autoScroll.checked && b_autoscroll.checked) && userNearBottom) live.scrollTop = live.scrollHeight;
-  }
-  function finalizeCurrentLine(finalText){
-    if (currentLineEl){
-      currentLineEl.classList.remove('liveLine');
-      currentLineEl.innerHTML = makeTimestampSpan() + finalText;
-      lastLineId = currentLineEl.id;
-      window.lastLineId = lastLineId;
-      currentLineEl = null;
-      if ((autoScroll.checked && b_autoscroll.checked) && userNearBottom) live.scrollTop = live.scrollHeight;
-      return;
-    }
-    // If we somehow didn't have a live line, append a fresh finalized one
-    makeLine(finalText, false);
-  }
-  function updateTailHTML(html){ setCurrentLineText(html); }
+  function mmss(){ if(!state.startTs) return '00:00'; const tsec=((Date.now()-state.startTs)/1000)|0; const mm=String((tsec/60)|0).padStart(2,"0"), ss=String(tsec%60).padStart(2,"0"); return `${mm}:${ss}`; }
+  window.mmss = mmss;
 
-  document.addEventListener('click',(e)=>{
-    const a=e.target.closest('a[href^="#t-"]');
-    if (!a) return;
-    e.preventDefault();
-    const id=a.getAttribute('href').slice(1);
-    const el=document.getElementById(id);
-    if (el){
-      live.scrollTop = el.offsetTop - 8;
-      el.style.outline='2px solid var(--accent)'; setTimeout(()=>el.style.outline='none',800);
+  function tag(el, state, text){ if(!el) return; el.classList.remove("ok","warn","bad"); el.classList.add(state); el.textContent=text; }
+
+  function updateSessionStatus(headline, sub, tone='ready', next){ dom.header.headline.textContent=headline; dom.header.sub.textContent=sub; dom.header.wrap.dataset.tone=tone; if(next) dom.header.next.textContent=next; }
+  function setNextAction(text){ dom.header.next.textContent=text; }
+
+  function updateMetrics(){
+    dom.metrics.duration.textContent = mmss();
+    const finalized = transcriptState.segments.filter(s=>s.finalized).length;
+    dom.metrics.segments.textContent = finalized;
+    dom.metrics.speakers.textContent = Math.max(1, transcriptState.speakerColors.size);
+    dom.metrics.highlights.textContent = insightsState.pinned.length;
+    dom.metrics.durationCard.classList.toggle('alert', state.running && mmss()>='45:00');
+    dom.metrics.segmentsCard.classList.toggle('alert', transcriptState.reviewQueue.length>0);
+  }
+
+  function startClock(){ stopClock(); state.clockTimer = setInterval(updateMetrics, 1000); }
+  function stopClock(){ if(state.clockTimer){ clearInterval(state.clockTimer); state.clockTimer=null; } }
+
+  function logActivity(type, message, data){
+    const entry = { ts:new Date(), type, message, data };
+    activityLog.unshift(entry);
+    if(activityLog.length>80) activityLog.pop();
+    renderActivityLog();
+  }
+
+  function renderActivityLog(){
+    if(!dom.activity.list) return;
+    if(!activityLog.length){ dom.activity.list.innerHTML = '<div class="insight-empty">No activity yet.</div>'; return; }
+    dom.activity.list.innerHTML = activityLog.map(entry=>{
+      const time = entry.ts.toLocaleTimeString([], {hour:'2-digit', minute:'2-digit', second:'2-digit'});
+      const data = revealLogDetails && entry.data ? `<div class="log-data">${escapeHtml(JSON.stringify(entry.data,null,2))}</div>` : '';
+      return `<div class="log-entry"><span class="log-time">${time}</span><span class="log-type">${escapeHtml(entry.type)}</span><span>${escapeHtml(entry.message)}</span>${data}</div>`;
+    }).join("");
+  }
+
+  dom.activity.toggle?.addEventListener('click',()=>{
+    revealLogDetails=!revealLogDetails;
+    dom.activity.toggle.textContent = revealLogDetails? 'Hide details' : 'Show details';
+    renderActivityLog();
+  });
+
+  function ensureSpeakerColor(name){
+    if(!transcriptState.speakerColors.has(name)){
+      const color = transcriptState.colorPalette[transcriptState.colorIndex % transcriptState.colorPalette.length];
+      transcriptState.colorIndex++;
+      transcriptState.speakerColors.set(name, color);
+    }
+    return transcriptState.speakerColors.get(name);
+  }
+
+  function speakerInitials(name){
+    const parts = String(name||'').split(/\s+/).filter(Boolean);
+    if(parts.length===0) return 'S1';
+    if(parts.length===1) return parts[0].slice(0,2).toUpperCase();
+    return (parts[0][0]+parts[parts.length-1][0]).toUpperCase();
+  }
+
+  function shouldShowTimestamps(){ return dom.transcript.timestamps.checked || behaviorControls.timestamps.checked; }
+
+  function renderSpeakerLegend(){
+    const entries = Array.from(transcriptState.speakerColors.entries());
+    if(!entries.length){ dom.transcript.legend.innerHTML = '<div class="insight-empty">Speakers appear as they speak.</div>'; return; }
+    dom.transcript.legend.innerHTML = entries.map(([name,color])=>`<span class="speaker-chip"><span class="dot" style="background:${color}"></span>${escapeHtml(name)}</span>`).join("");
+  }
+
+  function renderSegmentContent(seg, text){
+    const ts = shouldShowTimestamps() ? `<span class="ts" data-ts="${seg.ts}">[${seg.ts}]</span>` : '';
+    const color = ensureSpeakerColor(seg.speaker);
+    const badge = `<span class="speaker-badge" style="background:${color}">${speakerInitials(seg.speaker)}</span>`;
+    const label = `<span class="speaker-label">${badge}<span>${escapeHtml(seg.speaker)}</span></span>`;
+    seg.el.innerHTML = `${ts}${label}<span class="line-text">${escapeHtml(text)}</span>`;
+  }
+
+  function createSegment(speaker, text='', opts={}){
+    const seg = {
+      id:`seg-${Date.now()}-${++state.lineCounter}`,
+      speaker:speaker||'Speaker 1',
+      text:text||'',
+      ts:mmss(),
+      finalized:false,
+      el:document.createElement('div'),
+      confidence:null
+    };
+    seg.el.className='line liveLine';
+    seg.el.dataset.segmentId = seg.id;
+    seg.el.dataset.ts = seg.ts;
+    renderSegmentContent(seg, seg.text);
+    if(opts.system) seg.el.classList.add('system');
+    dom.transcript.container.appendChild(seg.el);
+    transcriptState.segments.push(seg);
+    transcriptState.liveSegment = seg;
+    if((dom.transcript.autoScroll.checked && behaviorControls.autoscroll.checked) && state.userNearBottom){ dom.transcript.container.scrollTop = dom.transcript.container.scrollHeight; }
+    renderSpeakerLegend();
+    return seg;
+  }
+
+  function finalizeSegment(seg, finalText, meta={}){
+    seg.finalized = true;
+    seg.text = finalText;
+    seg.el.classList.remove('liveLine');
+    seg.el.classList.add('finalized');
+    if(meta.highlight){ seg.el.classList.add('finalized-pop'); setTimeout(()=>seg.el.classList.remove('finalized-pop'),900); }
+    renderSegmentContent(seg, seg.text);
+    transcriptState.liveSegment = null;
+    updateMetrics();
+    logActivity('transcript', `Finalized ${seg.speaker}`, { text:seg.text.slice(0,200), ts:seg.ts, confidence:seg.confidence });
+  }
+
+  function queueReview(seg, reason, confidence){
+    if(transcriptState.flagged.has(seg.id)) return;
+    transcriptState.flagged.add(seg.id);
+    transcriptState.reviewQueue.unshift({ id:seg.id, speaker:seg.speaker, text:seg.text, reason, confidence, ts:seg.ts });
+    renderReviewQueue();
+  }
+
+  function renderReviewQueue(){
+    if(!transcriptState.reviewQueue.length){ dom.review.list.innerHTML = '<div class="insight-empty">No items flagged. Smooth sailing!</div>'; return; }
+    dom.review.list.innerHTML = transcriptState.reviewQueue.map(item=>{
+      const conf = typeof item.confidence === 'number' ? ` • confidence ${(item.confidence*100).toFixed(0)}%` : '';
+      return `<div class="review-card"><strong>${escapeHtml(item.speaker)}</strong><div>${escapeHtml(item.text)}</div><div class="meta">[${item.ts}] ${escapeHtml(item.reason)}${conf}</div><button data-review-resolve="${item.id}">Mark resolved</button></div>`;
+    }).join("");
+  }
+
+  dom.review.list.addEventListener('click', (e)=>{
+    const btn = e.target.closest('button[data-review-resolve]');
+    if(!btn) return;
+    const id = btn.dataset.reviewResolve;
+    transcriptState.reviewQueue = transcriptState.reviewQueue.filter(item=>item.id!==id);
+    transcriptState.flagged.delete(id);
+    renderReviewQueue();
+    logActivity('review','Flag resolved',{ segment:id });
+  });
+
+  function updateBuffering(show, message, warn=false){
+    if(!dom.transcript.buffer) return;
+    if(show){ dom.transcript.buffer.textContent = message||'Connecting…'; dom.transcript.buffer.classList.toggle('warn', warn); dom.transcript.buffer.classList.add('show'); }
+    else { dom.transcript.buffer.classList.remove('show'); dom.transcript.buffer.classList.remove('warn'); }
+  }
+  function heartbeat(){ state.lastMessageAt = Date.now(); updateBuffering(false); }
+
+  function startConnectivityWatch(){
+    stopConnectivityWatch();
+    state.connectivityTimer = setInterval(()=>{
+      if(!state.running) return;
+      const idle = Date.now() - state.lastMessageAt;
+      if(idle > 9000){ updateBuffering(true,'No transcript updates. Attempting to recover…', true); if(state.ws && state.ws.readyState !== 1 && behaviorControls.autoretry.checked) reconnectStream(); }
+      else if(idle > 5000){ updateBuffering(true,'Waiting for AssemblyAI…'); }
+    }, 2500);
+  }
+
+  function stopConnectivityWatch(){ if(state.connectivityTimer){ clearInterval(state.connectivityTimer); state.connectivityTimer=null; } }
+
+  function highlightTranscriptSearch(query){
+    const q = String(query||'').trim().toLowerCase();
+    transcriptState.segments.forEach(seg=>{
+      if(!seg.el) return;
+      if(!q){ seg.el.classList.remove('match'); return; }
+      const text = (seg.text||'').toLowerCase();
+      seg.el.classList.toggle('match', text.includes(q));
+    });
+  }
+
+  dom.transcript.search.addEventListener('input', ()=>highlightTranscriptSearch(dom.transcript.search.value));
+
+  function highlightNotesSearch(query){
+    const q = String(query||'').trim().toLowerCase();
+    const blocks = dom.notes.root.querySelectorAll('p, li, h1, h2, h3, h4, h5, h6, summary, div, section');
+    blocks.forEach(block=>{
+      const text = block.textContent.toLowerCase();
+      block.classList.toggle('note-match', q && text.includes(q));
+    });
+  }
+  dom.notes.search.addEventListener('input', ()=>highlightNotesSearch(dom.notes.search.value));
+
+  function rebuildQuickJump(){
+    const nodes = dom.notes.root.querySelectorAll('h1, h2, h3, h4, h5, h6, summary[data-note-section], [data-bookmark]');
+    if(!nodes.length){ dom.notes.quickJump.innerHTML = '<div class="insight-empty">Add headings or bookmarks to quick-jump.</div>'; return; }
+    const items = [];
+    nodes.forEach((node, idx)=>{
+      if(!node.id) node.id = `note-anchor-${Date.now()}-${idx}`;
+      let label = node.dataset.bookmarkLabel || node.textContent.trim() || `Bookmark ${idx+1}`;
+      label = label.slice(0,36);
+      items.push({ id:node.id, label });
+    });
+    dom.notes.quickJump.innerHTML = items.map(item=>`<button data-target="${item.id}">${escapeHtml(item.label)}</button>`).join('');
+  }
+
+  dom.notes.quickJump.addEventListener('click',(e)=>{
+    const btn = e.target.closest('button[data-target]');
+    if(!btn) return;
+    const el = document.getElementById(btn.dataset.target);
+    if(el){ el.scrollIntoView({behavior:'smooth', block:'center'}); el.classList.add('note-match'); setTimeout(()=>el.classList.remove('note-match'), 1200); }
+  });
+
+  function sanitizeName(s){ return String(s||"Lecture").replace(/[\\/\\:?*"<>|]/g,"_").slice(0,100); }
+
+  function getTranscriptSelection(){
+    const sel = window.getSelection();
+    if(!sel || sel.rangeCount===0) return { text:'', meta:null };
+    const range = sel.getRangeAt(0);
+    const ancestor = range.commonAncestorContainer;
+    if(!dom.transcript.container.contains(ancestor)) return { text:'', meta:null };
+    const text = sel.toString();
+    const startLine = range.startContainer.nodeType===1 ? range.startContainer.closest('.line') : range.startContainer.parentElement?.closest?.('.line');
+    const endLine = range.endContainer.nodeType===1 ? range.endContainer.closest('.line') : range.endContainer.parentElement?.closest?.('.line');
+    const meta = startLine || endLine ? { startTs:startLine?.dataset.ts || '', endTs:endLine?.dataset.ts || '' } : null;
+    return { text, meta };
+  }
+
+  function getTranscriptText(){ return Array.from(dom.transcript.container.querySelectorAll('.line')).map(n=>n.textContent).join("\n"); }
+
+  function renderInsights(){
+    if(!insightsState.items.length){ dom.insights.list.innerHTML=''; dom.insights.empty.style.display='block'; }
+    else {
+      dom.insights.empty.style.display='none';
+      dom.insights.list.innerHTML = insightsState.items.map(item=>{
+        return `<div class="insight-card" data-id="${item.id}"><h4>${escapeHtml(item.title)}</h4><div class="meta">${escapeHtml(item.meta)}</div><div>${item.html}</div><div class="actions"><button data-action="pin" data-id="${item.id}">Pin to notes</button><button data-action="copy" data-id="${item.id}">Copy</button><button data-action="remove" data-id="${item.id}">Remove</button></div></div>`;
+      }).join('');
+    }
+    renderPinned();
+    updateMetrics();
+  }
+
+  function renderPinned(){
+    if(!insightsState.pinned.length){ dom.insights.pinned.innerHTML='<div class="insight-empty">Pin AI cards to see them here.</div>'; return; }
+    dom.insights.pinned.innerHTML = insightsState.pinned.map(pin=>`<div class="pinned-card"><strong>${escapeHtml(pin.title)}</strong><div>${pin.html}</div><div class="meta">${escapeHtml(pin.meta)}</div><button data-remove-pin="${pin.id}">Remove</button></div>`).join('');
+  }
+
+  dom.insights.list.addEventListener('click',(e)=>{
+    const btn = e.target.closest('button[data-action]');
+    if(!btn) return;
+    const action = btn.dataset.action;
+    const id = btn.dataset.id;
+    if(action==='remove'){ insightsState.items = insightsState.items.filter(item=>item.id!==id); renderInsights(); logActivity('insight','Removed AI card',{ id }); return; }
+    const card = insightsState.items.find(item=>item.id===id);
+    if(!card) return;
+    if(action==='copy'){ navigator.clipboard?.writeText(card.text).then(()=>logActivity('insight','Copied AI summary',{ id })).catch(()=>{}); return; }
+    if(action==='pin'){ pinInsight(card); }
+  });
+
+  dom.insights.pinned.addEventListener('click',(e)=>{
+    const btn = e.target.closest('button[data-remove-pin]');
+    if(!btn) return;
+    const id = btn.dataset.removePin;
+    insightsState.pinned = insightsState.pinned.filter(pin=>pin.id!==id);
+    renderPinned();
+    updateMetrics();
+    logActivity('insight','Removed pinned summary',{ id });
+  });
+
+  function renderMarkdown(md){
+    const lines = String(md||'').split(/\r?\n/);
+    let html='';
+    let inList=false;
+    for(const line of lines){
+      const trimmed = line.trim();
+      if(!trimmed){ if(inList){ html+='</ul>'; inList=false; } continue; }
+      if(trimmed.startsWith('- ')){
+        if(!inList){ html+='<ul>'; inList=true; }
+        html+=`<li>${escapeHtml(trimmed.slice(2))}</li>`;
+        continue;
+      }
+      if(inList){ html+='</ul>'; inList=false; }
+      const heading = trimmed.match(/^(#{1,3})\s+(.*)$/);
+      if(heading){ const level = heading[1].length + 2; html+=`<h${level}>${escapeHtml(heading[2])}</h${level}>`; continue; }
+      html+=`<p>${escapeHtml(trimmed)}</p>`;
+    }
+    if(inList) html+='</ul>';
+    return html || `<p>${escapeHtml(md)}</p>`;
+  }
+
+  function pinInsight(card){
+    const pinned = { id:`pin-${Date.now()}`, title:card.title, html:card.html, meta:card.meta };
+    insightsState.pinned.unshift(pinned);
+    renderPinned();
+    updateMetrics();
+    const metaInfo = `Source: ${card.meta}`;
+    const markup = `<section class="callout" data-insight="${card.id}"><strong>${escapeHtml(card.title)}</strong>${card.html}<div class="sub">${escapeHtml(metaInfo)}</div></section>`;
+    dom.notes.root.focus();
+    document.execCommand('insertHTML', false, markup);
+    logActivity('notes','Pinned AI summary to notes',{ id:card.id });
+  }
+  dom.insights.generate.addEventListener('click', async ()=>{
+    const transcriptSel = getTranscriptSelection();
+    const targetText = transcriptSel.text.trim() || getTranscriptText();
+    if(!targetText){ alert('No transcript text available yet.'); return; }
+    const notesText = dom.insights.includeNotes.checked ? dom.notes.root.textContent.trim() : '';
+    dom.insights.generate.disabled = true;
+    const oldLabel = dom.insights.generate.textContent;
+    dom.insights.generate.textContent = 'Summarizing…';
+    try{
+      const payload = { transcript_text: targetText.slice(0, 18000) + (notesText ? `\n\nNOTES:\n${notesText.slice(0, 5000)}` : '') };
+      const r = await fetch(`${API}/api/summarize`, { method:'POST', headers:{'content-type':'application/json'}, body:JSON.stringify(payload) });
+      const j = await r.json();
+      if(!r.ok) throw new Error(j?.error||'summary_error');
+      const md = j.summary_md || '';
+      const html = renderMarkdown(md);
+      const metaParts = [];
+      if(transcriptSel.meta){
+        const span = transcriptSel.meta.startTs && transcriptSel.meta.endTs ? `${transcriptSel.meta.startTs}–${transcriptSel.meta.endTs}` : (transcriptSel.meta.startTs||transcriptSel.meta.endTs||'selection');
+        metaParts.push(`Selection ${span}`);
+      } else {
+        metaParts.push('Full session');
+      }
+      if(dom.insights.includeNotes.checked) metaParts.push('Notes context');
+      const card = { id:`ins-${Date.now()}`, title:'AI summary', text:md, html, meta:metaParts.join(' • ') };
+      insightsState.items.unshift(card);
+      if(insightsState.items.length>8) insightsState.items.pop();
+      renderInsights();
+      logActivity('insight','Generated AI summary',{ selection:!!transcriptSel.text, notes:dom.insights.includeNotes.checked });
+    }catch(e){
+      alert('Summary failed: '+(e?.message||e));
+      logActivity('insight-error','AI summary failed',{ error:String(e) });
+    }finally{
+      dom.insights.generate.disabled=false;
+      dom.insights.generate.textContent=oldLabel;
     }
   });
 
-  function toPCM16(f32){ const out = new Int16Array(f32.length); for (let i=0;i<f32.length;i++){ let s=f32[i]; s=Math.max(-1,Math.min(1,s)); out[i]=s<0?s*0x8000:s*0x7FFF; } return out; }
+  function updatePrivacyStatus(){
+    const parts=[];
+    parts.push(privacyPrefs.storeTranscript ? 'Transcript included on save' : 'Transcript stays local');
+    parts.push(privacyPrefs.storeAudio ? 'Audio uploads allowed' : 'Audio stays local');
+    parts.push(privacyPrefs.keepLocalNotes ? 'Notes persist locally' : 'Notes wiped on clear');
+    if(privacyPrefs.autoDeleteMinutes>0) parts.push(`Auto-delete after ${privacyPrefs.autoDeleteMinutes} min`);
+    else parts.push('Manual retention');
+    dom.privacy.status.textContent = parts.join(' • ');
+    storage.set('lc_privacy_v1', privacyPrefs);
+  }
+
+  dom.privacy.storeTranscript.addEventListener('change',()=>{ privacyPrefs.storeTranscript = dom.privacy.storeTranscript.checked; updatePrivacyStatus(); logActivity('privacy','Updated transcript preference',{ storeTranscript:privacyPrefs.storeTranscript }); });
+  dom.privacy.storeAudio.addEventListener('change',()=>{ privacyPrefs.storeAudio = dom.privacy.storeAudio.checked; updatePrivacyStatus(); logActivity('privacy','Updated audio preference',{ storeAudio:privacyPrefs.storeAudio }); });
+  dom.privacy.keepLocalNotes.addEventListener('change',()=>{ privacyPrefs.keepLocalNotes = dom.privacy.keepLocalNotes.checked; updatePrivacyStatus(); logActivity('privacy','Updated notes retention',{ keepLocalNotes:privacyPrefs.keepLocalNotes }); });
+  dom.privacy.autoDelete.addEventListener('change',()=>{ privacyPrefs.autoDeleteMinutes = parseInt(dom.privacy.autoDelete.value,10)||0; updatePrivacyStatus(); logActivity('privacy','Updated auto-delete',{ autoDeleteMinutes:privacyPrefs.autoDeleteMinutes }); });
+  dom.privacy.nuke.addEventListener('click',()=>{ clearSessionData('Manual clear'); });
+
+  function scheduleAutoDelete(){
+    if(state.autoDeleteTimer){ clearTimeout(state.autoDeleteTimer); state.autoDeleteTimer=null; }
+    if(privacyPrefs.autoDeleteMinutes>0){
+      state.autoDeleteTimer = setTimeout(()=>{ clearSessionData('Auto-delete timer'); logActivity('privacy','Auto-deleted session',{ minutes:privacyPrefs.autoDeleteMinutes }); }, privacyPrefs.autoDeleteMinutes * 60 * 1000);
+    }
+  }
+
+  function clearSessionData(reason){
+    transcriptState.segments = [];
+    transcriptState.reviewQueue = [];
+    transcriptState.flagged.clear();
+    transcriptState.liveSegment = null;
+    dom.transcript.container.innerHTML='';
+    renderReviewQueue();
+    renderSpeakerLegend();
+    updateMetrics();
+    insightsState.items = [];
+    insightsState.pinned = [];
+    renderInsights();
+    if(!privacyPrefs.keepLocalNotes){ dom.notes.root.innerHTML='<p>• Welcome back. Shortcuts on: Cmd/Ctrl-Shift-8 bullets, Cmd/Ctrl-Shift-7 numbers, Cmd-Shift-- em dash —, Cmd-Shift-. arrow →, Cmd+M timestamp marker.</p>'; }
+    rebuildQuickJump();
+    highlightNotesSearch(dom.notes.search.value);
+    state.audioBlob=null;
+    state.wavChunks=[];
+    logActivity('privacy','Cleared session data',{ reason });
+  }
+
+  function toPCM16(f32){ const out = new Int16Array(f32.length); for(let i=0;i<f32.length;i++){ let s=f32[i]; s=Math.max(-1,Math.min(1,s)); out[i]=s<0?s*0x8000:s*0x7FFF; } return out; }
+  function wavEncode(pcm16, sampleRate){ const numChannels=1, bytesPerSample=2, blockAlign=numChannels*bytesPerSample, byteRate=sampleRate*blockAlign; const dataSize=pcm16.length*bytesPerSample; const buffer=new ArrayBuffer(44+dataSize); const v=new DataView(buffer); let o=0; const w16=x=>{v.setUint16(o,x,true);o+=2;}, w32=x=>{v.setUint32(o,x,true);o+=4;}; w32(0x46464952); w32(36+dataSize); w32(0x45564157); w32(0x20746d66); w32(16); w16(1); w16(1); w32(sampleRate); w32(byteRate); w16(blockAlign); w16(16); w32(0x61746164); w32(dataSize); new Int16Array(buffer,44,pcm16.length).set(pcm16); return new Blob([buffer],{type:"audio/wav"}); }
 
   async function openWS(){
     try{
-      const tr = await fetch(API+"/api/aai-token?expires_in_seconds=300");
-      if (!tr.ok) throw new Error("token");
-      const {token} = await tr.json();
+      const tr = await fetch(`${API}/api/aai-token?expires_in_seconds=300`);
+      if(!tr.ok) throw new Error('token');
+      const { token } = await tr.json();
       const s = new WebSocket(`wss://streaming.assemblyai.com/v3/ws?sample_rate=16000&encoding=pcm_s16le&token=${token}`);
-      s.binaryType="arraybuffer";
-      s.onopen=()=>tag(stStream,"ok","Stream");
-      s.onclose=()=>tag(stStream,"warn","Stream");
-      s.onerror=()=>tag(stStream,"bad","Stream");
-      s.onmessage=(m)=>{ if(typeof m.data!=="string") return; try{
-        const j=JSON.parse(m.data);
-        const txt=j.formatted_transcript||j.transcript||(j.turn&&(j.turn.formatted_transcript||j.turn.transcript))||j.text;
-        if(!txt) return;
-        if (sentenceChk.checked || b_sentence.checked){
-          const trimmed = txt.trim();
-          const done = /[.!?]\s*$/.test(trimmed);
-          if (done){
-            transcriptText += (tsChk.checked||b_timestamps.checked ? (`[${mmss()}] `) : '') + trimmed + "\n";
-            finalizeCurrentLine(trimmed);
-            sentBuf = '';
-          } else {
-            sentBuf = txt + ' ';
-            setCurrentLineText(sentBuf);
-          }
-        } else {
-          setCurrentLineText(txt);
-        }
-      }catch(_){}};
+      s.binaryType='arraybuffer';
+      s.onopen=()=>{ tag(dom.status.stream,'ok','Stream'); heartbeat(); updateBuffering(false); logActivity('stream','Connected to AssemblyAI'); };
+      s.onerror=()=>{ tag(dom.status.stream,'bad','Stream'); updateBuffering(true,'Stream error – check network',true); logActivity('stream','Stream error',{ running:state.running }); };
+      s.onclose=()=>{ tag(dom.status.stream,'warn','Stream'); if(state.running) updateBuffering(true,'Stream closed. Reconnecting…'); if(state.running && behaviorControls.autoretry.checked){ setTimeout(()=>{ reconnectStream(); }, 1500); } };
+      s.onmessage=(m)=>{ if(typeof m.data!=="string") return; try{ const payload=JSON.parse(m.data); handleTranscriptMessage(payload); }catch(e){ console.error('transcript parse',e); } };
       return s;
-    }catch(e){ tag(stStream,"warn","Stream"); return null; }
+    }catch(e){ tag(dom.status.stream,'warn','Stream'); updateBuffering(true,'Unable to open stream',true); logActivity('stream-error','Failed to open websocket',{ error:String(e) }); return null; }
   }
+
+  async function reconnectStream(){
+    if(state.ws){ try{ state.ws.onclose=null; state.ws.close(); }catch(e){} state.ws=null; }
+    state.ws = await openWS();
+  }
+
+  function detectSpeaker(payload){
+    const speaker = payload.speaker || payload.channel || payload?.turn?.speaker;
+    if(speaker){
+      const label = String(speaker).toLowerCase().includes('speaker') ? speaker : `Speaker ${speaker}`;
+      return label.replace(/_/g,' ').replace(/\s+/g,' ').trim() || 'Speaker';
+    }
+    if(transcriptState.liveSegment && !transcriptState.liveSegment.finalized) return transcriptState.liveSegment.speaker;
+    if(transcriptState.segments.length){ return transcriptState.segments[transcriptState.segments.length-1].speaker; }
+    return 'Speaker 1';
+  }
+
+  function determineFinal(payload, text){
+    if(payload.message_type && /final/i.test(payload.message_type)) return true;
+    if(payload.type && /final/i.test(payload.type)) return true;
+    if(payload.is_final) return true;
+    return /[.!?…]$/.test(text);
+  }
+
+  function handleTranscriptMessage(j){
+    heartbeat();
+    const raw = j.formatted_transcript || j.transcript || (j.turn && (j.turn.formatted_transcript||j.turn.transcript)) || j.text;
+    if(!raw) return;
+    const text = String(raw).trim();
+    if(!text) return;
+    const speaker = detectSpeaker(j);
+    const conf = typeof j.confidence === 'number' ? j.confidence : (typeof j.turn?.confidence === 'number' ? j.turn.confidence : null);
+    const sentenceMode = dom.transcript.sentence.checked || behaviorControls.sentence.checked;
+    let seg = transcriptState.liveSegment;
+    if(!seg || seg.speaker !== speaker || seg.finalized){
+      if(seg && !seg.finalized && seg.text.trim()){ finalizeSegment(seg, seg.text.trim(), { highlight:false }); queueReview(seg,'Speaker changed mid-sentence', seg.confidence); }
+      seg = createSegment(speaker);
+    }
+    seg.text = text;
+    seg.confidence = conf;
+    renderSegmentContent(seg, seg.text);
+    seg.el.classList.add('partial');
+    if((dom.transcript.autoScroll.checked && behaviorControls.autoscroll.checked) && state.userNearBottom){ dom.transcript.container.scrollTop = dom.transcript.container.scrollHeight; }
+    const isFinal = sentenceMode ? determineFinal(j, text) : (j.message_type==='FinalTranscript' || determineFinal(j,text));
+    if(isFinal){ finalizeSegment(seg, text, { highlight:true }); seg.el.classList.remove('partial'); if(conf!==null && conf<0.85) queueReview(seg,'Low confidence', conf); }
+  }
+
+  dom.transcript.container.addEventListener('scroll',()=>{ state.userNearBottom = nearBottom(dom.transcript.container); }, { passive:true });
 
   async function listMics(){
     try{
       await navigator.mediaDevices.getUserMedia({audio:true});
       const devs = await navigator.mediaDevices.enumerateDevices();
-      const auds = devs.filter(d=>d.kind==="audioinput");
-      micSel.innerHTML = auds.map(d=>`<option value="${d.deviceId}">${d.label||"(default)"}</option>`).join("") || `<option value="">(default)</option>`;
-      tag(stMic,"ok","Mic");
-    }catch(e){ tag(stMic,"bad","Mic"); }
+      const auds = devs.filter(d=>d.kind==='audioinput');
+      dom.controls.micSel.innerHTML = auds.map(d=>`<option value="${d.deviceId}">${escapeHtml(d.label||"(default)")}</option>`).join("") || `<option value="">(default)</option>`;
+      tag(dom.status.mic,'ok','Mic');
+    }catch(e){ tag(dom.status.mic,'bad','Mic'); }
   }
   navigator.mediaDevices?.addEventListener?.('devicechange', ()=>listMics());
   listMics();
-
-  function sanitizeName(s){ return String(s||"Lecture").replace(/[\/\\:?*"<>|]/g,"_").slice(0,100); }
-  let audioUploadURL="";
-
   async function start(){
-    if (running) return;
-    running=true; paused=false; startTs=Date.now(); transcriptText=""; sentBuf=""; audioBlob=null; wavChunks=[]; lineCounter=0; lastLineId=null;
+    if(state.running) return;
+    state.running=true; state.paused=false; state.startTs=Date.now();
+    transcriptState.segments=[]; transcriptState.reviewQueue=[]; transcriptState.flagged.clear(); transcriptState.liveSegment=null; transcriptState.speakerColors.clear(); transcriptState.colorIndex=0;
+    dom.transcript.container.innerHTML=''; renderSpeakerLegend(); renderReviewQueue();
+    updateSessionStatus('Recording in progress','Microphone live. Keep an eye on the review queue for flagged items.','recording','Next action: Pause or stop when ready.');
+    setNextAction('Next action: Pause or Stop.');
+    state.wavChunks=[]; state.audioBlob=null; state.lineCounter=0; insightsState.items=[]; insightsState.pinned=[]; renderInsights();
+    updateMetrics(); startClock(); startConnectivityWatch();
+    logActivity('session','Recording started',{ title:dom.controls.title.value || '', class:dom.controls.classSel.value || '' });
     try{
-      const deviceId = micSel.value || undefined;
-      mediaStream = await navigator.mediaDevices.getUserMedia({audio:{deviceId,channelCount:1},video:false});
-      audioCtx = new (window.AudioContext||window.webkitAudioContext)();
-      wavSampleRate = audioCtx.sampleRate || 44100;
-      source = audioCtx.createMediaStreamSource(mediaStream);
-      processor = audioCtx.createScriptProcessor(4096,1,1);
-      ws = await openWS();
-      processor.onaudioprocess = (e)=>{
-        if (paused) return;
+      const deviceId = dom.controls.micSel.value || undefined;
+      state.mediaStream = await navigator.mediaDevices.getUserMedia({audio:{deviceId,channelCount:1},video:false});
+      state.audioCtx = new (window.AudioContext||window.webkitAudioContext)();
+      state.wavSampleRate = state.audioCtx.sampleRate || 44100;
+      state.source = state.audioCtx.createMediaStreamSource(state.mediaStream);
+      state.processor = state.audioCtx.createScriptProcessor(4096,1,1);
+      state.ws = await openWS();
+      state.processor.onaudioprocess = (e)=>{
+        if(state.paused) return;
         const ch=e.inputBuffer.getChannelData(0);
         const pcm16 = toPCM16(ch);
-        wavChunks.push(pcm16);
-        let peak=0; for(let i=0;i<ch.length;i++) peak=Math.max(peak,Math.abs(ch[i])); vu.style.width=Math.min(100,(peak*200)|0)+"%";
-        if (ws && ws.readyState===1){
-          // Quick downsample to 16k for WebSocket
-          const sr=e.inputBuffer.sampleRate||wavSampleRate; const ratio=sr/16000;
-          const len=Math.floor(ch.length/ratio); const out=new Int16Array(len);
+        state.wavChunks.push(pcm16);
+        let peak=0; for(let i=0;i<ch.length;i++) peak=Math.max(peak,Math.abs(ch[i])); dom.controls.vu.style.width=Math.min(100,(peak*200)|0)+"%";
+        if(state.ws && state.ws.readyState===1){
+          const sr=e.inputBuffer.sampleRate||state.wavSampleRate; const ratio=sr/16000; const len=Math.floor(ch.length/ratio); const out=new Int16Array(len);
           for(let o=0,i=0;o<len;o++,i+=ratio){ let s=ch[i|0]; s=Math.max(-1,Math.min(1,s)); out[o]=s<0?s*0x8000:s*0x7FFF; }
-          ws.send(out.buffer);
+          try{ state.ws.send(out.buffer); }catch(err){ console.warn('ws send',err); }
         }
       };
-      source.connect(processor); processor.connect(audioCtx.destination);
-      finalizeCurrentLine("Session started");
+      state.source.connect(state.processor); state.processor.connect(state.audioCtx.destination);
+      const sysSeg = createSegment(speakerSystem,'Session started',{ system:true });
+      finalizeSegment(sysSeg, 'Session started', { highlight:false });
     }catch(e){
-      appendLineHTML("Mic denied/unavailable. Type notes while we sort it.");
-      tag(stMic,"bad","Mic");
-      running=false;
+      const sysSeg = createSegment(speakerSystem,'Mic denied/unavailable',{ system:true });
+      finalizeSegment(sysSeg, 'Mic denied/unavailable', { highlight:false });
+      tag(dom.status.mic,'bad','Mic');
+      state.running=false; stopClock(); stopConnectivityWatch();
     }
   }
-  function wavEncode(pcm16, sampleRate){
-    const numChannels=1, bytesPerSample=2, blockAlign=numChannels*bytesPerSample, byteRate=sampleRate*blockAlign;
-    const dataSize = pcm16.length*bytesPerSample; const buffer=new ArrayBuffer(44+dataSize); const v=new DataView(buffer); let o=0;
-    const w16=(x)=>{v.setUint16(o,x,true);o+=2}, w32=(x)=>{v.setUint32(o,x,true);o+=4};
-    w32(0x46464952); w32(36+dataSize); w32(0x45564157); w32(0x20746d66); w32(16); w16(1); w16(1); w32(sampleRate); w32(byteRate); w16(blockAlign); w16(16); w32(0x61746164); w32(dataSize);
-    new Int16Array(buffer,44,pcm16.length).set(pcm16); return new Blob([buffer],{type:"audio/wav"});
-  }
+
+  function pause(){ if(!state.running) return; state.paused=true; dom.controls.pause.style.display='none'; dom.controls.resume.style.display=''; updateSessionStatus('Recording paused','Microphone muted until you resume.','paused','Next action: Resume to continue.'); logActivity('session','Paused recording',{}); }
+  function resume(){ if(!state.running) return; state.paused=false; dom.controls.pause.style.display=''; dom.controls.resume.style.display='none'; updateSessionStatus('Recording in progress','Microphone live again.','recording','Next action: Pause or stop when ready.'); logActivity('session','Resumed recording',{}); }
+
   async function stop(){
-    paused=false;
-    if (processor){ processor.disconnect(); processor=null; }
-    if (source){ source.disconnect(); source=null; }
-    if (audioCtx){ try{ await audioCtx.close(); }catch(_){} audioCtx=null; }
-    if (mediaStream){ mediaStream.getTracks().forEach(t=>t.stop()); mediaStream=null; }
-    if (ws){ try{ ws.close(); }catch(_){} ws=null; }
-    vu.style.width="0%";
-    finalizeCurrentLine("Session stopped."); summaryBtn.style.display=''; tag(stStream,"warn","Stream"); running=false;
-
+    state.paused=false;
+    if(state.processor){ state.processor.disconnect(); state.processor=null; }
+    if(state.source){ state.source.disconnect(); state.source=null; }
+    if(state.audioCtx){ try{ await state.audioCtx.close(); }catch(_){} state.audioCtx=null; }
+    if(state.mediaStream){ state.mediaStream.getTracks().forEach(t=>t.stop()); state.mediaStream=null; }
+    if(state.ws){ try{ state.ws.close(); }catch(_){} state.ws=null; }
+    dom.controls.vu.style.width='0%';
+    updateSessionStatus('Session stopped','Audio cached locally. Review notes and save when ready.','ready','Next action: Generate insights or save.');
+    const sysSeg = createSegment(speakerSystem,'Session stopped',{ system:true });
+    finalizeSegment(sysSeg, 'Session stopped.', { highlight:false });
     try{
-      const total = wavChunks.reduce((acc,a)=>acc + a.length, 0);
-      const pcm = new Int16Array(total); let off=0; for(const c of wavChunks){ pcm.set(c,off); off+=c.length; }
-      audioBlob = wavEncode(pcm, wavSampleRate);
-    }catch(_){ audioBlob=null; }
-  }
-  startBtn.onclick=()=>{ startBtn.style.display='none'; pauseBtn.style.display=''; stopBtn.style.display=''; resumeBtn.style.display='none'; summaryBtn.style.display='none'; start(); };
-  pauseBtn.onclick=()=>{ paused=true; pauseBtn.style.display='none'; resumeBtn.style.display=''; };
-  resumeBtn.onclick=()=>{ paused=false; pauseBtn.style.display=''; resumeBtn.style.display='none'; };
-  stopBtn.onclick=()=>{ stop(); pauseBtn.style.display='none'; resumeBtn.style.display='none'; stopBtn.style.display='none'; startBtn.style.display=''; };
-
-  /* ======== SHORTCUTS (Docs/Word-ish) ======== */
-  // Lists: Cmd/Ctrl-Shift-8 bullet, Cmd/Ctrl-Shift-7 numbered
-  document.addEventListener('keydown', (e)=>{
-    if (!notes.contains(document.activeElement)) return; // only when editing notes
-    // Tab indent/outdent
-    if (e.key==='Tab'){
-      e.preventDefault();
-      const block=window.getSelection()?.anchorNode?.parentElement;
-      if(block){ const cur=parseInt(block.style.marginLeft||'0',10); const delta=e.shiftKey?-24:24; block.style.marginLeft=Math.max(0,cur+delta)+'px'; }
-      return;
-    }
-    const cmd = (e.metaKey||e.ctrlKey) && e.shiftKey;
-    if (cmd && e.key==='8'){ e.preventDefault(); document.execCommand('insertUnorderedList'); return; }
-    if (cmd && e.key==='7'){ e.preventDefault(); document.execCommand('insertOrderedList'); return; }
-    // Em dash: Cmd-Shift-- (Mac-like). Arrow: Cmd-Shift-. 
-    if ((e.metaKey||e.ctrlKey) && e.shiftKey && e.key === '_'){ e.preventDefault(); document.execCommand('insertText', false, '—'); return; }
-    if ((e.metaKey||e.ctrlKey) && e.shiftKey && e.key === '>'){ e.preventDefault(); document.execCommand('insertText', false, '→'); return; }
-  }, true);
-
-  // === Autoformat: Word/Google-like shortcuts for Notes ===
-(function(){
-  const notes = document.getElementById("notes");
-
-  function getBlockEl() {
-    const sel = window.getSelection();
-    if (!sel || sel.rangeCount === 0) return null;
-    let n = sel.getRangeAt(0).startContainer;
-    if (n.nodeType === 3) n = n.parentNode; // text → element
-    while (n && n !== notes && !/^(DIV|P|LI)$/i.test(n.tagName)) n = n.parentNode;
-    return (n === notes) ? null : n;
+      const total = state.wavChunks.reduce((acc,a)=>acc+a.length,0);
+      const pcm = new Int16Array(total); let off=0; for(const c of state.wavChunks){ pcm.set(c,off); off+=c.length; }
+      state.audioBlob = wavEncode(pcm, state.wavSampleRate);
+    }catch(_){ state.audioBlob=null; }
+    dom.controls.pause.style.display='none'; dom.controls.resume.style.display='none'; dom.controls.stop.style.display='none'; dom.controls.start.style.display=''; dom.controls.summary.style.display='';
+    state.running=false; stopClock(); stopConnectivityWatch(); scheduleAutoDelete();
+    logActivity('session','Stopped recording',{ duration:mmss() });
   }
 
-  // Convert current block to UL/OL after removing typed marker
-  function toList(listType) {
-    const sel = window.getSelection();
-    const block = getBlockEl();
-    if (!block) return;
-    const text = block.textContent;
-    if (listType === "ul") {
-      block.textContent = text.replace(/^(\s*)-\s+/, "$1");
-    } else {
-      block.textContent = text.replace(/^(\s*)\d+\.\s+/, "$1");
-    }
-    const r = document.createRange();
-    r.selectNodeContents(block);
-    sel.removeAllRanges();
-    sel.addRange(r);
-    document.execCommand(listType === "ul" ? "insertUnorderedList" : "insertOrderedList");
-  }
+  dom.controls.start.addEventListener('click',()=>{ dom.controls.start.style.display='none'; dom.controls.pause.style.display=''; dom.controls.stop.style.display=''; dom.controls.summary.style.display='none'; start(); });
+  dom.controls.pause.addEventListener('click',()=>pause());
+  dom.controls.resume.addEventListener('click',()=>resume());
+  dom.controls.stop.addEventListener('click',()=>{ dom.controls.pause.style.display='none'; dom.controls.resume.style.display='none'; dom.controls.stop.style.display='none'; dom.controls.start.style.display=''; stop(); });
 
-  // Replace symbols and detect list markers after each input
-  function autoformatInput() {
-    const block = getBlockEl();
-    if (!block) return;
+  dom.transcript.refresh.addEventListener('click',()=>{ reconnectStream(); logActivity('stream','Manual refresh requested',{}); });
 
-    // 1) Symbol replacements everywhere in the block
-    // "-->" → arrow,  "--" → em dash (only when used like punctuation)
-    block.innerHTML = block.innerHTML
-      .replace(/-->/g, "→")
-      .replace(/(^|[\s])--(?=[\s.,;!?)]|$)/g, "$1—");
-
-    // 2) List triggers only at line start
-    const text = block.textContent;                 // plain text of this block
-    const trimmedStart = text.replace(/^\s+/, "");  // ignore leading spaces
-
-    if (/^-\s$/.test(trimmedStart) || /^-\s+/.test(trimmedStart)) {
-      toList("ul");
-      return;
-    }
-    if (/^\d+\.\s/.test(trimmedStart)) {
-      toList("ol");
-      return;
-    }
-  }
-
-  notes.addEventListener("input", autoformatInput, { passive: true });
-
-  // Tab / Shift-Tab: indent/outdent (list-aware)
-  notes.addEventListener("keydown", (e) => {
-    if (e.key !== "Tab") return;
-    const sel = window.getSelection();
-    if (!sel || sel.rangeCount === 0) return;
-    if (!notes.contains(sel.anchorNode)) return;
-
-    e.preventDefault();
-    // If inside a list item, change list nesting; otherwise indent margin
-    const li = (sel.anchorNode.nodeType === 1 ? sel.anchorNode : sel.anchorNode.parentElement)?.closest("li");
-    if (li) {
-      document.execCommand(e.shiftKey ? "outdent" : "indent");
-      return;
-    }
-    const block = getBlockEl();
-    if (!block) return;
-    const cur = parseInt(block.style.marginLeft || "0", 10);
-    const delta = e.shiftKey ? -24 : 24;
-    block.style.marginLeft = Math.max(0, cur + delta) + "px";
-  }, true);
-
-  // Cmd/Ctrl+M = linked timestamp marker (kept)
-})();
-
-  // Cmd/Ctrl + M: insert linked timestamp to last transcript line
-  document.addEventListener('keydown', (e)=>{
-    if (!b_markers.checked) return;
-    const hot = (e.metaKey||e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase()==='m';
-    if (hot){
-      e.preventDefault();
-      const label = `[⏱ ${mmss()}]`;
-      const href = lastLineId ? `#${lastLineId}` : '#';
-      notes.focus();
-      document.execCommand('insertHTML', false, `<a href="${href}">${label}</a> `);
-    }
-  });
-
-  /* ======== NOTES TOOLBAR (font/highlighter colors + 30 fonts) ======== */
-  const sizeSel=byId("fontSizeSel"), sizeBox=byId("fontSizeBox"), famSel=byId("fontFamilySel");
-  for (let px=4; px<=60; px++){ const o=document.createElement('option'); o.value=px; o.textContent=px+'px'; if(px===16) o.selected=true; sizeSel.appendChild(o); }
-  const FONT_CHOICES = [
-    /* 5 classic serif */ "Times New Roman","Georgia","Libre Baskerville","Merriweather","Source Serif 4",
-    /* 10 classic sans */ "Arial","Helvetica","Inter","Roboto","Open Sans","Noto Sans","IBM Plex Sans","Source Sans 3","Manrope","Work Sans",
-    /* 5 quirky serif */ "Playfair Display","Cinzel","Alegreya","Bodoni Moda","Cormorant Garamond",
-    /* 10 quirky sans */ "Fira Sans","Montserrat","Poppins","Raleway","Outfit","Space Grotesk","Quicksand","Fira Sans","Exo 2","Work Sans"
-  ];
-  famSel.innerHTML = FONT_CHOICES.map(f=>`<option>${f}</option>`).join("");
-
-  function clamp(v,a,b){return Math.max(a,Math.min(b,v));}
-  function applyStyleToSelection(style){
-    const sel=window.getSelection(); if(!sel||sel.rangeCount===0) return false;
-    const rng=sel.getRangeAt(0); if(rng.collapsed) return false;
-    try{ const span=document.createElement('span'); Object.assign(span.style, style); rng.surroundContents(span); return true; }catch(e){ return false; }
-  }
-  sizeSel.onchange=()=>{ const px=clamp(parseInt(sizeSel.value,10)||16,4,60); sizeBox.value=px; if(!applyStyleToSelection({fontSize:px+'px'})){ notes.style.fontSize=px+'px'; } };
-  sizeBox.onchange=()=>{ const px=clamp(parseInt(sizeBox.value,10)||16,4,60); sizeSel.value=px; if(!applyStyleToSelection({fontSize:px+'px'})){ notes.style.fontSize=px+'px'; } };
-  famSel.onchange = ()=>{ const fam=famSel.value; if(!applyStyleToSelection({fontFamily:fam})){ notes.style.fontFamily=fam; } };
-
-  byId("boldBtn").onclick=()=>document.execCommand('bold');
-  byId("italicBtn").onclick=()=>document.execCommand('italic');
-  byId("undoBtn").onclick=()=>document.execCommand('undo');
-  byId("redoBtn").onclick=()=>document.execCommand('redo');
-  byId("unhlBtn").onclick=()=>document.execCommand('removeFormat');
-
-  const fontColorBtn=byId("fontColorBtn"), fontColor=byId("fontColor"), hlBtn=byId("hlBtn"), hlColor=byId("hlColor"), hexBox=byId("hexBox");
-  fontColorBtn.onclick=()=>fontColor.click();
-  hlBtn.onclick=()=>hlColor.click();
-  fontColor.oninput=()=>{ const c=fontColor.value; hexBox.value=c; if(!applyStyleToSelection({color:c})){ notes.style.color=c; } };
-  hlColor.oninput=()=>{ const c=hlColor.value; hexBox.value=c; applyStyleToSelection({backgroundColor:c}); };
-  hexBox.onchange=()=>{ const c=hexBox.value.trim(); if(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(c)){ applyStyleToSelection({backgroundColor:c}); } };
-
-  /* ======== SUMMARY (unchanged) ======== */
   function summarize(){
-    const transcript = Array.from(live.querySelectorAll('.line')).map(n=>n.textContent).join("\n");
+    const transcript = Array.from(dom.transcript.container.querySelectorAll('.line')).map(n=>n.textContent).join("\n");
     const bullets = transcript.split(/[.;!?]/).map(s=>s.trim()).filter(Boolean).slice(0,8);
     const h2=document.createElement('h2'); h2.textContent='Summary'; h2.style.margin='16px 0 6px'; h2.style.fontSize='20px';
     const ul=document.createElement('ul'); bullets.forEach(b=>{ const li=document.createElement('li'); li.textContent=b; ul.appendChild(li); });
-    notes.appendChild(h2); notes.appendChild(ul);
+    dom.notes.root.appendChild(h2); dom.notes.root.appendChild(ul);
+    logActivity('notes','Generated in-note summary',{ count:bullets.length });
   }
-  summaryBtn.onclick=summarize;
+  dom.controls.summary.addEventListener('click', summarize);
 
-  /* ======== SAVE: download WAV + upload to server + Airtable/Make ======== */
   function payload(audio_url){
+    const transcriptText = privacyPrefs.storeTranscript ? Array.from(dom.transcript.container.querySelectorAll('.line')).map(n=>n.textContent).join("\n") : '';
     return {
-      title: titleBox.value || (classSel.value?`${classSel.value} — ${new Date().toISOString().slice(0,10)}`:'Lecture'),
-      class_name: classSel.value || "",
-      duration_seconds: startTs ? Math.round((Date.now()-startTs)/1000) : 0,
-      notes_html: notes.innerHTML,
-      transcript_text: Array.from(live.querySelectorAll('.line')).map(n=>n.textContent).join("\n"),
+      title: dom.controls.title.value || (dom.controls.classSel.value?`${dom.controls.classSel.value} — ${new Date().toISOString().slice(0,10)}`:'Lecture'),
+      class_name: dom.controls.classSel.value || "",
+      duration_seconds: state.startTs ? Math.round((Date.now()-state.startTs)/1000) : 0,
+      notes_html: dom.notes.root.innerHTML,
+      transcript_text: transcriptText,
       audio_url: audio_url || ""
     };
   }
+
   async function saveAll(){
-    // Download WAV locally
-    try{
-      const nameBase = sanitizeName(titleBox.value || classSel.value || "Lecture");
-      if (audioBlob){ const fname=`${new Date().toISOString().replace(/[:.]/g,'-')}—${nameBase}.wav`; const a=document.createElement("a"); a.href=URL.createObjectURL(audioBlob); a.download=fname; a.click(); setTimeout(()=>URL.revokeObjectURL(a.href),1200); }
-    }catch(_){}
-    // Upload audio, then save to Airtable via server
+    try{ if(state.audioBlob && privacyPrefs.storeAudio){ const nameBase=sanitizeName(dom.controls.title.value || dom.controls.classSel.value || 'Lecture'); const fname=`${new Date().toISOString().replace(/[:.]/g,'-')}—${nameBase}.wav`; const a=document.createElement('a'); a.href=URL.createObjectURL(state.audioBlob); a.download=fname; a.click(); setTimeout(()=>URL.revokeObjectURL(a.href),1200); } }catch(_){ }
     let audioUrl="";
     try{
-      if (audioBlob){
-        const fname = `${new Date().toISOString().replace(/[:.]/g,'-')}—${sanitizeName(titleBox.value||classSel.value||"Lecture")}.wav`;
-        const r = await fetch(`${API}/api/upload-audio?filename=${encodeURIComponent(fname)}`, { method:"POST", headers:{ "content-type":"application/octet-stream" }, body: await audioBlob.arrayBuffer() });
-        const j = await r.json(); if (r.ok && j?.url) audioUrl=j.url;
+      if(state.audioBlob && privacyPrefs.storeAudio){
+        const fname=`${new Date().toISOString().replace(/[:.]/g,'-')}—${sanitizeName(dom.controls.title.value||dom.controls.classSel.value||"Lecture")}.wav`;
+        const r = await fetch(`${API}/api/upload-audio?filename=${encodeURIComponent(fname)}`, { method:'POST', headers:{'content-type':'application/octet-stream'}, body: await state.audioBlob.arrayBuffer() });
+        const j=await r.json(); if(r.ok && j?.url) audioUrl=j.url;
       }
-    }catch(_){}
+    }catch(_){ }
     try{
-      const r=await fetch(API+"/api/save",{method:"POST",headers:{'content-type':'application/json'},body:JSON.stringify(payload(audioUrl))});
+      const r=await fetch(`${API}/api/save`,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(payload(audioUrl))});
       await r.json();
-      tag(stApi,"ok","API");
-      alert("Saved: audio downloaded, Airtable updated, Make triggered (if configured).");
+      tag(dom.status.api,'ok','API');
+      alert('Saved: audio downloaded, Airtable updated, Make triggered (if configured).');
+      logActivity('save','Session saved',{ audioUploaded:privacyPrefs.storeAudio, transcriptIncluded:privacyPrefs.storeTranscript });
     }catch(e){
-      tag(stApi,"warn","API");
-      alert("Server save failed. Your audio was downloaded locally.");
+      tag(dom.status.api,'warn','API');
+      alert('Server save failed. Your audio was downloaded locally.');
+      logActivity('save-error','Save failed',{ error:String(e) });
     }
   }
-  saveBtn.onclick=saveAll;
+  dom.controls.save.addEventListener('click', saveAll);
 
-  /* ======== Boot: classes + status ======== */
-  function renderClassOptions(list){ classSel.innerHTML='<option value="">Choose class…</option>'+list.map(n=>`<option>${n}</option>`).join("")+'<option value="__other__">Other…</option>'; }
+  function renderClassOptions(list){ dom.controls.classSel.innerHTML='<option value="">Choose class…</option>'+list.map(n=>`<option>${escapeHtml(n)}</option>`).join("")+'<option value="__other__">Other…</option>'; }
   (function bootClasses(){ const saved=JSON.parse(localStorage.getItem("lc_classes")||"[]"); renderClassOptions(saved);
     if (location.hash.startsWith("#classes=")){ try{ const arr=JSON.parse(decodeURIComponent(location.hash.slice(9))); const cleaned=[...new Set(arr.map(x=>String(x).trim()).filter(Boolean))].sort(); const merged=[...new Set([...(saved||[]),...cleaned])].sort(); localStorage.setItem("lc_classes",JSON.stringify(merged)); renderClassOptions(merged); history.replaceState(null,"",location.pathname+location.search); alert('Imported '+cleaned.length+' classes from Canvas.'); }catch{} }
   })();
-  classSel.onchange=()=>{ if (classSel.value==="__other__"){ const n=prompt("Enter class name:")||""; if(n.trim()){ classSel.insertAdjacentHTML('afterbegin', `<option>${n.trim()}</option>`); classSel.value=n.trim(); } } titleBox.value = classSel.value ? `${classSel.value} — ${new Date().toISOString().slice(0,10)}` : ""; };
+  dom.controls.classSel.onchange=()=>{ if (dom.controls.classSel.value==="__other__"){ const n=prompt("Enter class name:")||""; if(n.trim()){ dom.controls.classSel.insertAdjacentHTML('afterbegin', `<option>${escapeHtml(n.trim())}</option>`); dom.controls.classSel.value=n.trim(); } } dom.controls.title.value = dom.controls.classSel.value ? `${dom.controls.classSel.value} — ${new Date().toISOString().slice(0,10)}` : ""; };
 
-  function quitScribeCat(){
-    [quitDrawerBtn, quitTopBtn].forEach(btn=>{ if(btn){ btn.disabled=true; btn.textContent='Quitting…'; }});
-    fetch(API+'/api/quit',{method:'POST'}).catch(()=>{});
-    setTimeout(()=>{ window.close(); },200);
-    setTimeout(()=>{ window.location.href='about:blank'; },600);
+  function insertHTML(html){ dom.notes.root.focus(); document.execCommand('insertHTML', false, html); rebuildQuickJump(); }
+  dom.notes.insertSection.addEventListener('click',()=>{ const id=`section-${Date.now()}`; insertHTML(`<details class="note-section" open id="${id}"><summary data-note-section contenteditable="true">New section</summary><div class="note-section-body"><p>Start typing…</p></div></details><p></p>`); logActivity('notes','Inserted collapsible section',{}); });
+  dom.notes.insertBookmark.addEventListener('click',()=>{ const id=`bookmark-${Date.now()}`; insertHTML(`<span class="note-bookmark" data-bookmark id="${id}" contenteditable="true">Bookmark</span>`); logActivity('notes','Inserted bookmark',{}); });
+  dom.notes.insertCallout.addEventListener('click',()=>{ insertHTML('<div class="callout" contenteditable="true"><strong>Callout:</strong> Drop key insight or reminder.</div>'); logActivity('notes','Inserted callout',{}); });
+  dom.notes.insertTable.addEventListener('click',()=>{ insertHTML('<table class="note-table"><thead><tr><th>Heading 1</th><th>Heading 2</th></tr></thead><tbody><tr><td>Row 1</td><td>Row 1</td></tr><tr><td>Row 2</td><td>Row 2</td></tr></tbody></table>'); logActivity('notes','Inserted table',{}); });
+  dom.notes.insertTodo.addEventListener('click',()=>{ insertHTML('<ul class="todo-list"><li><input type="checkbox"/> <span>Task</span></li><li><input type="checkbox"/> <span>Follow-up</span></li></ul>'); logActivity('notes','Inserted checklist',{}); });
+
+  dom.notes.root.addEventListener('input',()=>{ highlightNotesSearch(dom.notes.search.value); rebuildQuickJump(); });
+  dom.notes.root.addEventListener('toggle',()=>rebuildQuickJump());
+
+  dom.notes.fontColorBtn.onclick=()=>dom.notes.fontColor.click();
+  dom.notes.hlBtn.onclick=()=>dom.notes.hlColor.click();
+  dom.notes.fontColor.oninput=()=>{ const c=dom.notes.fontColor.value; dom.notes.hexBox.value=c; if(!applyStyleToSelection({color:c})){ dom.notes.root.style.color=c; } };
+  dom.notes.hlColor.oninput=()=>{ const c=dom.notes.hlColor.value; dom.notes.hexBox.value=c; applyStyleToSelection({backgroundColor:c}); };
+  dom.notes.hexBox.onchange=()=>{ const c=dom.notes.hexBox.value.trim(); if(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i.test(c)){ applyStyleToSelection({backgroundColor:c}); } };
+  dom.notes.unhl.onclick=()=>document.execCommand('removeFormat');
+  dom.notes.bold.onclick=()=>document.execCommand('bold');
+  dom.notes.italic.onclick=()=>document.execCommand('italic');
+  dom.notes.undo.onclick=()=>document.execCommand('undo');
+  dom.notes.redo.onclick=()=>document.execCommand('redo');
+
+  const FONT_CHOICES = ["Times New Roman","Georgia","Libre Baskerville","Merriweather","Source Serif 4","Arial","Helvetica","Inter","Roboto","Open Sans","Noto Sans","IBM Plex Sans","Source Sans 3","Manrope","Work Sans","Playfair Display","Cinzel","Alegreya","Bodoni Moda","Cormorant Garamond","Fira Sans","Montserrat","Poppins","Raleway","Outfit","Space Grotesk","Quicksand","Exo 2"];
+  for(let px=4; px<=60; px++){ const o=document.createElement('option'); o.value=px; o.textContent=px+'px'; if(px===16) o.selected=true; dom.notes.fontSizeSel.appendChild(o); }
+  dom.notes.fontFamilySel.innerHTML = FONT_CHOICES.map(f=>`<option>${f}</option>`).join('');
+
+  function applyStyleToSelection(style){ const sel=window.getSelection(); if(!sel||sel.rangeCount===0) return false; const rng=sel.getRangeAt(0); if(rng.collapsed) return false; try{ const span=document.createElement('span'); Object.assign(span.style, style); rng.surroundContents(span); return true; }catch(e){ return false; } }
+  dom.notes.fontSizeSel.onchange=()=>{ const px=clamp(parseInt(dom.notes.fontSizeSel.value,10)||16,4,60); dom.notes.fontSizeBox.value=px; if(!applyStyleToSelection({fontSize:px+'px'})){ dom.notes.root.style.fontSize=px+'px'; } };
+  dom.notes.fontSizeBox.onchange=()=>{ const px=clamp(parseInt(dom.notes.fontSizeBox.value,10)||16,4,60); dom.notes.fontSizeSel.value=px; if(!applyStyleToSelection({fontSize:px+'px'})){ dom.notes.root.style.fontSize=px+'px'; } };
+  dom.notes.fontFamilySel.onchange=()=>{ const fam=dom.notes.fontFamilySel.value; if(!applyStyleToSelection({fontFamily:fam})){ dom.notes.root.style.fontFamily=fam; } };
+
+  document.addEventListener('keydown',(e)=>{
+    if(!dom.notes.root.contains(document.activeElement)) return;
+    if(e.key==='Tab'){ e.preventDefault(); const block=window.getSelection()?.anchorNode?.parentElement; if(block){ const cur=parseInt(block.style.marginLeft||'0',10); const delta=e.shiftKey?-24:24; block.style.marginLeft=Math.max(0,cur+delta)+'px'; } return; }
+    const cmd=(e.metaKey||e.ctrlKey)&&e.shiftKey;
+    if(cmd && e.key==='8'){ e.preventDefault(); document.execCommand('insertUnorderedList'); return; }
+    if(cmd && e.key==='7'){ e.preventDefault(); document.execCommand('insertOrderedList'); return; }
+    if((e.metaKey||e.ctrlKey) && e.shiftKey && e.key === '_'){ e.preventDefault(); document.execCommand('insertText', false, '—'); return; }
+    if((e.metaKey||e.ctrlKey) && e.shiftKey && e.key === '>'){ e.preventDefault(); document.execCommand('insertText', false, '→'); return; }
+  }, true);
+
+  document.addEventListener('keydown',(e)=>{
+    if(!behaviorControls.markers.checked) return;
+    const hot=(e.metaKey||e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase()==='m';
+    if(hot){ e.preventDefault(); const label=`[⏱ ${mmss()}]`; const href='#'+(transcriptState.segments.length ? transcriptState.segments[transcriptState.segments.length-1]?.id : ''); dom.notes.root.focus(); document.execCommand('insertHTML', false, `<a href="${href}">${label}</a> `); }
+  });
+
+  document.addEventListener('click',(e)=>{
+    const a=e.target.closest('a[href^="#seg-"]');
+    if(!a) return;
+    const id=a.getAttribute('href').slice(1);
+    const el=document.getElementById(id);
+    if(el){ dom.transcript.container.scrollTop = el.offsetTop - 8; el.style.outline='2px solid var(--accent)'; setTimeout(()=>el.style.outline='none',800); }
+  });
+
+  const themePresets = {
+    "Clean": {bg:'#f6f7fb',surface:'#fff',ink:'#101319',sub:'#6a7180',border:'#e3e7ef',brand:'#ffd200',accent:'#506fff',accent2:'#ff5c8a',btn:'#fff',btnText:'#111'},
+    "Dark Ink": {bg:'#0f1115',surface:'#161a22',ink:'#f1f5f9',sub:'#93a4b3',border:'#232b3a',brand:'#ffd200',accent:'#8aa9ff',accent2:'#ff95b2',btn:'#1f2532',btnText:'#fff'},
+    "High Contrast": {bg:'#0b0d17',surface:'#12182a',ink:'#fefefe',sub:'#cbd5f5',border:'#23305b',brand:'#ffd200',accent:'#4be9b9',accent2:'#a855f7',btn:'#1d2643',btnText:'#fefefe'},
+    "Forest": {bg:'#f2f7f4',surface:'#ffffff',ink:'#0c2116',sub:'#476453',border:'#d9e7df',brand:'#ffd200',accent:'#1f8a6f',accent2:'#3b82f6',btn:'#fff',btnText:'#0c2116'},
+    "Plum": {bg:'#f7f4fa',surface:'#ffffff',ink:'#201226',sub:'#6c5a76',border:'#e8e1ee',brand:'#ffd200',accent:'#7b3eff',accent2:'#ff5ea8',btn:'#fff',btnText:'#201226'},
+    "Citrus": {bg:'#fffdf6',surface:'#ffffff',ink:'#1f1407',sub:'#6b5a44',border:'#efe7d6',brand:'#ffd200',accent:'#ff7d26',accent2:'#0ea5e9',btn:'#fff',btnText:'#1f1407'}
+  };
+  dom.theme.select.innerHTML = Object.keys(themePresets).map(name=>`<option value="${name}">${name}</option>`).join('');
+
+  function contrastRatio(hex1, hex2){
+    function luminance(hex){ const c=parseInt(hex.slice(1),16); const r=(c>>16)&255, g=(c>>8)&255, b=c&255; const vals=[r,g,b].map(v=>{ v/=255; return v<=0.03928?v/12.92:Math.pow((v+0.055)/1.055,2.4); }); return 0.2126*vals[0]+0.7152*vals[1]+0.0722*vals[2]; }
+    const L1=luminance(hex1), L2=luminance(hex2); return (Math.max(L1,L2)+0.05)/(Math.min(L1,L2)+0.05);
   }
-  [quitDrawerBtn, quitTopBtn].forEach(btn=>btn&&btn.addEventListener('click', quitScribeCat));
+
+  function applyThemeVars(theme){
+    const r=document.documentElement.style;
+    const warn=dom.theme.warning;
+    const pairs=[[theme.surface,theme.ink],[theme.bg,theme.ink],[theme.btn,theme.btnText]];
+    let needsWarn=false;
+    pairs.forEach(([bg,fg])=>{ try{ if(contrastRatio(bg,fg)<4.5) needsWarn=true; }catch{} });
+    r.setProperty('--bg',theme.bg); r.setProperty('--surface',theme.surface); r.setProperty('--ink',theme.ink);
+    r.setProperty('--sub',theme.sub); r.setProperty('--border',theme.border); r.setProperty('--brand',theme.brand);
+    r.setProperty('--accent',theme.accent); r.setProperty('--accent-2',theme.accent2);
+    r.setProperty('--btn',theme.btn); r.setProperty('--btn-text',theme.btnText);
+    warn.style.display = needsWarn ? 'block' : 'none';
+  }
+
+  function applyThemeByName(name){ const theme = themePresets[name] || themePresets['Clean']; applyThemeVars(theme); themePref=name; storage.set('lc_theme_v2', themePref); dom.theme.select.value=name; }
+  dom.theme.apply.addEventListener('click',()=>applyThemeByName(dom.theme.select.value));
+  applyThemeByName(themePref);
+
+  function syncBehaviorControls(){ Object.entries(behaviorControls).forEach(([key,el])=>{ el.checked = behaviorPrefs[key]; el.addEventListener('change',()=>{ behaviorPrefs[key]=el.checked; storage.set('lc_behaviors_v2', behaviorPrefs); }); }); }
+  syncBehaviorControls();
+
+  function applyLayout(){ document.body.classList.toggle('stacked', layoutPrefs.stacked); dom.layout.stacked.checked = layoutPrefs.stacked; storage.set('lc_layout_v1', layoutPrefs); }
+  dom.layout.stacked.addEventListener('change',()=>{ layoutPrefs.stacked = dom.layout.stacked.checked; applyLayout(); });
+  dom.layout.quick.addEventListener('click',()=>{ layoutPrefs.stacked = !layoutPrefs.stacked; applyLayout(); });
+  applyLayout();
+
+  dom.privacy.storeTranscript.checked = privacyPrefs.storeTranscript;
+  dom.privacy.storeAudio.checked = privacyPrefs.storeAudio;
+  dom.privacy.keepLocalNotes.checked = privacyPrefs.keepLocalNotes;
+  dom.privacy.autoDelete.value = String(privacyPrefs.autoDeleteMinutes||0);
+  updatePrivacyStatus();
+
+  dom.gear.addEventListener('click',()=>{ dom.drawer.style.display = (dom.drawer.style.display==='none'||!dom.drawer.style.display)?'block':'none'; });
+  dom.manageBtn.addEventListener('click',()=> dom.drawer.style.display='block');
+
+  function checkEnv(){
+    dom.env.results.textContent='Checking…';
+    fetch(`${API}/api/diag-env`).then(r=>r.json()).then(j=>{
+      state.envStatus=j;
+      const lines=[`AssemblyAI key ${j.AAI_API_KEY?'✓':'✗'}`,`OpenAI key ${j.OPENAI_API_KEY?'✓':'✗'}`,`Airtable ${j.AIRTABLE_PAT?'✓':'✗'} (table ${escapeHtml(j.AIRTABLE_TABLE)})`, `Make webhook ${j.MAKE_WEBHOOK_URL?'✓':'✗'}`];
+      dom.env.results.innerHTML = lines.map(line=>`<div>${line}</div>`).join('');
+      logActivity('env','Checked environment',j);
+    }).catch(e=>{ dom.env.results.textContent='Diagnostics failed: '+e; logActivity('env-error','Env check failed',{ error:String(e) }); });
+  }
+  dom.env.button.addEventListener('click', checkEnv);
+
+  function downloadPrivacyReport(){
+    const report = {
+      generated_at: new Date().toISOString(),
+      session: { running: state.running, duration:mmss(), segments: transcriptState.segments.length },
+      privacy: privacyPrefs,
+      review_queue: transcriptState.reviewQueue.length,
+      insights: { total: insightsState.items.length, pinned: insightsState.pinned.length },
+      environment: state.envStatus
+    };
+    const blob = new Blob([JSON.stringify(report,null,2)], {type:'application/json'});
+    const url = URL.createObjectURL(blob);
+    const a=document.createElement('a'); a.href=url; a.download=`scribe-privacy-report-${Date.now()}.json`; a.click(); setTimeout(()=>URL.revokeObjectURL(url),1200);
+    logActivity('privacy','Downloaded privacy report',{});
+  }
+  byId('downloadPrivacyReportBtn').addEventListener('click', downloadPrivacyReport);
+
+  function quitScribeCat(){ [dom.quitDrawer, dom.quitTop].forEach(btn=>{ if(btn){ btn.disabled=true; btn.textContent='Quitting…'; }}); fetch(`${API}/api/quit`,{method:'POST'}).catch(()=>{}); setTimeout(()=>{ window.close(); },200); setTimeout(()=>{ window.location.href='about:blank'; },600); }
+  [dom.quitDrawer, dom.quitTop].forEach(btn=>btn&&btn.addEventListener('click', quitScribeCat));
+
+  fetch(`${API}/`).then(r=>tag(dom.status.api, r.ok?'ok':'bad', 'API')).catch(()=>tag(dom.status.api,'bad','API'));
+
+  window.addEventListener('beforeunload',()=>{ if(state.ws){ try{ state.ws.close(); }catch{} } });
+
+  rebuildQuickJump();
+  renderActivityLog();
+  renderInsights();
+  renderReviewQueue();
+  updateMetrics();
+  setInterval(updateMetrics, 5000);
 })();
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Rebuilt the single-page layout with a responsive command center, prominent session status pulse, metric cards, and a dedicated insights column.
- Implemented richer transcript streaming logic with speaker legends, buffering/reconnect handling, review queue, and transcript search/highlight utilities.
- Added an AI insights workflow, quick-jump navigation, privacy diagnostics/reporting, and enhanced notes tooling for callouts, sections, tables, and checklists.

## Testing
- npm i
- npx tauri info
- npx tauri dev *(fails: tauri.conf.json is missing in this repo)*
- curl http://localhost:8787/api

------
https://chatgpt.com/codex/tasks/task_e_68cac32ce45c832daec3d4ec019715bd