### PR TITLE
Add desktop launcher scripts

### DIFF
--- a/LaunchScribeCatDesktop.bat
+++ b/LaunchScribeCatDesktop.bat
@@ -1,0 +1,11 @@
+@echo off
+setlocal enabledelayedexpansion
+cd /d "%~dp0"
+
+if not exist node_modules (
+  echo [ScribeCat] Installing dependencies (npm install)...
+  call npm install
+)
+
+echo [ScribeCat] Starting Tauri dev server (leave this window open)...
+call npm run tauri:dev

--- a/LaunchScribeCatDesktop.command
+++ b/LaunchScribeCatDesktop.command
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")"
+"${PWD}/scripts/launch-tauri-desktop.sh"

--- a/docs/desktop-launcher.md
+++ b/docs/desktop-launcher.md
@@ -1,0 +1,19 @@
+# ScribeCat Desktop Launcher Button
+
+Use the provided launcher files in the repository root to open the ScribeCat desktop (Tauri) app without remembering any commands.
+
+## macOS
+- Double-click **`LaunchScribeCatDesktop.command`**.
+- A Terminal window appears, installs dependencies if `node_modules` is missing, and then runs `npm run tauri:dev`.
+- Keep the window open while you use ScribeCat; close it (or press `Ctrl+C`) to stop the app.
+
+## Windows
+- Double-click **`LaunchScribeCatDesktop.bat`**.
+- Command Prompt will install dependencies if needed and then execute `npm run tauri:dev`.
+- Leave the window open; close it or press `Ctrl+C` to stop the app.
+
+## Linux / WSL
+- Run `./scripts/launch-tauri-desktop.sh` from the repository root or `bash LaunchScribeCatDesktop.command`.
+- The script mirrors the behavior described above.
+
+> Both launchers assume you have [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) available and will reuse the pinned Tauri CLI from `package.json`.

--- a/scripts/launch-tauri-desktop.sh
+++ b/scripts/launch-tauri-desktop.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Resolve repository root relative to this script
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "$REPO_ROOT"
+
+# Helper to print highlighted status messages
+info() {
+  printf '\n\033[1;36m[ScribeCat]\033[0m %s\n' "$1"
+}
+
+info "Preparing to launch the ScribeCat desktop app..."
+
+if [ ! -d "node_modules" ]; then
+  info "Installing dependencies (npm install)..."
+  npm install
+fi
+
+info "Starting Tauri dev server (this window will stay open)..."
+# Use npm to invoke the local Tauri CLI pinned in package.json
+npm run tauri:dev


### PR DESCRIPTION
## Summary
- add macOS and Windows launchers at the repo root that run the desktop app via `npm run tauri:dev`
- provide a shared bash helper to bootstrap the launcher flow and install dependencies when missing
- document how to use the new launchers across macOS, Windows, and Linux/WSL

## Testing
- not run (launcher scripts are wrappers around the existing `npm run tauri:dev` command)


------
https://chatgpt.com/codex/tasks/task_e_68cad8b49b10832d9ed9039820f52c55