### PR TITLE
chore: add desktop launch script

### DIFF
--- a/ScribeCat.command
+++ b/ScribeCat.command
@@ -1,7 +1,24 @@
-#!/usr/bin/env bash
-cd "$(dirname "$0")"
-node server.mjs &
-SERVER_PID=$!
-sleep 1
-open "http://127.0.0.1:8787/"
-wait $SERVER_PID
+#!/bin/zsh
+set -euo pipefail
+cd "$(cd "$(dirname "$0")" && pwd)"
+export PORT="${PORT:-1420}"
+export API_PORT="${API_PORT:-8787}"
+mkdir -p logs
+
+# start API server only if not already running
+if ! lsof -ti :$API_PORT >/dev/null 2>&1; then
+  if [ -f server/package.json ]; then
+    (corepack enable || true) >/dev/null 2>&1
+    (npm --prefix server ci || npm --prefix server i) >/dev/null 2>&1
+    nohup npm --prefix server run start > logs/api.log 2>&1 & echo $! > .pid_api
+  elif [ -f server/server.mjs ]; then
+    nohup node server/server.mjs > logs/api.log 2>&1 & echo $! > .pid_api
+  elif [ -f server/index.mjs ]; then
+    nohup node server/index.mjs > logs/api.log 2>&1 & echo $! > .pid_api
+  fi
+fi
+
+# run app (Tauri dev); static UI server should be started by beforeDevCommand
+(corepack enable || true) >/dev/null 2>&1
+if [ -f pnpm-lock.yaml ]; then pnpm i --frozen-lockfile || pnpm i; elif [ -f yarn.lock ]; then yarn install --frozen-lockfile || yarn install; elif [ -f package.json ]; then npm ci || npm i; fi
+exec npx tauri dev


### PR DESCRIPTION
## Summary
- replace the legacy launcher with a zsh script that bootstraps the API server, installs dependencies, and starts the Tauri dev environment with logging.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb06c24d4c832da7846acbc469012d