### PR TITLE
Create backup directory and Markdown documents

### DIFF
--- a/backups/organized-20250918T110600Z/console-summary.txt
+++ b/backups/organized-20250918T110600Z/console-summary.txt
@@ -1,0 +1,18 @@
+DRY RUN SUMMARY
+===============
+Context: Preparing to reorganize HTML backups into a curated Markdown knowledge base without touching runtime assets.
+
+Key Risks
+- Mislabeling HTML snapshots could mislead release notes.
+- Forgetting `.gitignore` rules may hide newly added backup documents.
+- Skipping validation could allow broken asset references to slip by.
+
+Validation Commands
+1. node scripts/fetch_assets.mjs && bash scripts/ensure_icon.sh
+2. bash scripts/start_static.sh && curl -sI http://localhost:1420/ | head -n 1
+3. npx tauri info
+4. npx tauri dev
+
+Next Steps
+- Draft Markdown note under docs/notes/ summarizing backup inventory.
+- Schedule follow-up to convert priority HTML snapshots into portable Markdown entries.

--- a/backups/organized-20250918T110600Z/plan.md
+++ b/backups/organized-20250918T110600Z/plan.md
@@ -1,0 +1,33 @@
+# Backup Consolidation Dry Run Plan
+
+## Objective
+Organize legacy HTML backups into a structured, reviewable format while drafting supporting documentation for the docs/notes workspace.
+
+## Scope
+- Catalogue key snapshots from existing `index.*.html` files.
+- Draft evergreen notes in `docs/notes/` describing how to navigate the backup set and future curation steps.
+- Keep the application runnable by avoiding any changes to build scripts, runtime assets, or source code outside Markdown/text notes.
+
+## Proposed Steps
+1. Review current backups in the repository to map significant milestones (version markers, timestamps, and anomaly reports).
+2. Summarize observed states and outstanding questions in a new Markdown note under `docs/notes/`.
+3. Capture action items for future cleanup, including prioritizing which HTML backups to convert to Markdown and which to archive externally.
+4. Cross-reference the dev workflow so documentation readers know how to validate the static assets before promoting changes.
+
+## Deliverables
+- `docs/notes/` Markdown note summarizing the backup landscape, outstanding tasks, and validation checklist.
+- Companion console summary enumerating risks and validation commands to run before and after touching backups.
+
+## Validation Checklist
+- `node scripts/fetch_assets.mjs && bash scripts/ensure_icon.sh`
+- `bash scripts/start_static.sh && curl -sI http://localhost:1420/ | head -n 1`
+- `npx tauri info`
+- `npx tauri dev`
+
+## Risks and Mitigations
+- **Stale HTML snapshots**: Risk of documenting outdated UI behaviours. *Mitigation*: flag uncertain snapshots and suggest verifying against current production builds.
+- **Ignored backups directory**: `.gitignore` excludes `/backups/`, so new files require `git add -f`. *Mitigation*: record this requirement and double-check `git status` before committing.
+- **Validation fatigue**: Commands are resource-intensive. *Mitigation*: recommend running them selectively when markup changes touch runtime assumptions.
+
+## Rollback Strategy
+Use `git revert <commit-sha>` on the documentation commit if the plan proves inaccurate or needs to be replaced wholesale.

--- a/docs/notes/backup-curation-2025-09-18.md
+++ b/docs/notes/backup-curation-2025-09-18.md
@@ -1,0 +1,30 @@
+# Backup Curation Notes — 2025-09-18
+
+## Inventory Highlights
+- Legacy HTML snapshots in the repository root capture UI versions such as `index.before_v1.9.8.html`, `index.before_v1.9.7.html`, and `index.backup-20250915-211503.html`.
+- Structured plans already live under `backups/organized-2025-09-18T02-21-35Z/` and `backups/organized-2025-09-18T11-05-22Z/`, outlining earlier triage and offender tracking.
+- Newly added `backups/organized-20250918T110600Z/` holds the current dry-run plan and console summary to guide consolidation work.
+
+## Current Observations
+- The `.gitignore` entry for `/backups/` still applies, so forced adds (`git add -f`) are required for any new backup documentation.
+- Multiple HTML backups share similar timestamps; we should compare their critical UI states before pruning duplicates.
+- No Markdown exists yet to explain how backup HTML maps to production releases—this note aims to seed that documentation.
+
+## Action Items
+1. Cross-check HTML snapshots against release tags or changelog entries to anchor them in time.
+2. Decide which backups warrant Markdown conversions (e.g., major release transitions or incidents documented in `index.broken*.txt`).
+3. Follow the plan in `backups/organized-20250918T110600Z/plan.md` to create a consistent template for future backup notes.
+4. When ready to execute, run the validation checklist below to ensure the static bundle still serves correctly.
+
+## Validation Checklist
+- `node scripts/fetch_assets.mjs && bash scripts/ensure_icon.sh`
+- `bash scripts/start_static.sh && curl -sI http://localhost:1420/ | head -n 1`
+- `npx tauri info`
+- `npx tauri dev`
+
+## Risks and Mitigations
+- **Documentation drift**: Without periodic updates, these notes could fall out of sync with actual backups. *Mitigation*: schedule reviews when new backups are added.
+- **Command fatigue**: The validation list is long; confirm which steps are necessary before each run. *Mitigation*: annotate future notes with the minimum required checks.
+
+## Rollback Guidance
+If these notes need to be undone or replaced, revert commit `chore(docs): create backups/ directory and seed project notes (text-only)` using `git revert <commit-sha>` to restore the previous documentation state.


### PR DESCRIPTION
## Summary
- Add a dry-run plan in `backups/organized-20250918T110600Z/` that explains objectives, deliverables, risks, and validation steps for consolidating HTML backups.
- Capture a concise console summary of key risks, validation commands, and next actions for the backup reorganization effort.
- Seed `docs/notes/backup-curation-2025-09-18.md` with inventory highlights, action items, validation checklists, and rollback guidance for the documentation effort.

## Testing
- Not run (documentation-only changes)

## Rollback
- `git revert b9413ffae0e39c65f1cdaa6ead1c7a972f4eb0c6`


------
https://chatgpt.com/codex/tasks/task_e_68cbe766daec832d8d9872d0af24d280