### PR TITLE
feat(ui): add header + status panel with version, text-only

### DIFF
--- a/scripts/start_static.sh
+++ b/scripts/start_static.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+lsof -ti :1420 | xargs -r kill -9 || true
+node -e 'const fs=require("fs");const j=JSON.parse(fs.readFileSync("src-tauri/tauri.conf.json","utf8"));fs.mkdirSync("web",{recursive:true});fs.writeFileSync("web/version.json",JSON.stringify({productName:j.productName,version:j.version}))'
+node scripts/static_web.mjs >/dev/null 2>&1 &
+PID=$!
+for i in {1..40}; do
+  curl -sfI http://localhost:1420/ >/dev/null && { echo "static web at http://localhost:1420"; echo $PID > backups/static_server.pid; exit 0; }
+  sleep 0.25
+done
+echo "static server failed to start on :1420" >&2
+exit 1

--- a/web/app.js
+++ b/web/app.js
@@ -1,0 +1,91 @@
+const statusEls = {
+  internet: document.getElementById("statusInternet"),
+  static: document.getElementById("statusStatic"),
+  app: document.getElementById("statusApp"),
+};
+
+const versionEls = {
+  product: document.getElementById("devShellProduct"),
+  version: document.getElementById("devShellVersion"),
+};
+
+const FALLBACK_PRODUCT = "ScribeCat";
+const FALLBACK_VERSION = "0.1.0";
+
+function setStatus(el, state, text) {
+  if (!el) return;
+  el.textContent = text;
+  el.classList.remove("is-ok", "is-bad", "is-warn");
+  if (state) {
+    el.classList.add(state);
+  }
+}
+
+function applyVersion(productName, version) {
+  if (versionEls.product) {
+    versionEls.product.textContent = productName || FALLBACK_PRODUCT;
+  }
+  if (versionEls.version) {
+    versionEls.version.textContent = version || FALLBACK_VERSION;
+  }
+}
+
+async function loadVersion() {
+  try {
+    const res = await fetch("/version.json", { cache: "no-store" });
+    if (res.ok) {
+      const data = await res.json();
+      const productName = (data?.productName || "").trim();
+      const version = (data?.version || "").trim();
+      applyVersion(productName || FALLBACK_PRODUCT, version || FALLBACK_VERSION);
+      return;
+    }
+  } catch (err) {
+    console.debug("version.json unavailable", err);
+  }
+  applyVersion(FALLBACK_PRODUCT, FALLBACK_VERSION);
+}
+
+async function checkInternet() {
+  setStatus(statusEls.internet, "is-warn", "checking…");
+  try {
+    await fetch("https://example.com/", { mode: "no-cors" });
+    setStatus(statusEls.internet, "is-ok", "reachable");
+  } catch (err) {
+    console.debug("internet check failed", err);
+    setStatus(statusEls.internet, "is-bad", "unreachable");
+  }
+}
+
+async function checkStaticServer() {
+  setStatus(statusEls.static, "is-warn", "checking…");
+  try {
+    const res = await fetch("/index.html", { cache: "no-store" });
+    if (res.ok) {
+      setStatus(statusEls.static, "is-ok", "ok");
+    } else {
+      setStatus(statusEls.static, "is-bad", "down");
+    }
+  } catch (err) {
+    console.debug("static server check failed", err);
+    setStatus(statusEls.static, "is-bad", "down");
+  }
+}
+
+function markAppReady() {
+  setStatus(statusEls.app, "is-ok", "ready");
+}
+
+function initAppStatus() {
+  setStatus(statusEls.app, "is-warn", "loading…");
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", markAppReady, { once: true });
+  } else {
+    markAppReady();
+  }
+}
+
+loadVersion();
+checkInternet();
+checkStaticServer();
+initAppStatus();

--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,8 @@
 <meta name="viewport" content="width=device-width,initial-scale=1"/>
 <title>ScribeCat v1.9.9</title>
 
+<link rel="stylesheet" href="/style.css"/>
+
 <!-- Google Fonts: 30-note menu (5 classic serif, 10 classic sans, 5 quirky serif, 10 quirky sans) -->
 <link href="https://fonts.googleapis.com/css2?family=Libre+Baskerville:wght@400;700&family=Merriweather:wght@400;700&family=Source+Serif+4:wght@400;700&family=IBM+Plex+Serif:wght@400;700&family=Crimson+Text:wght@400;700&family=Inter:wght@400;700&family=Roboto:wght@400;700&family=Open+Sans:wght@400;700&family=Noto+Sans:wght@400;700&family=IBM+Plex+Sans:wght@400;700&family=Source+Sans+3:wght@400;700&family=Manrope:wght@400;700&family=Work+Sans:wght@400;700&family=Fira+Sans:wght@400;700&family=Montserrat:wght@400;700&family=Poppins:wght@400;700&family=Raleway:wght@400;700&family=Outfit:wght@400;700&family=Space+Grotesk:wght@400;700&family=Playfair+Display:wght@400;700&family=Cinzel:wght@400;700&family=Alegreya:wght@400;700&family=Bodoni+Moda:wght@400;700&family=Cormorant+Garamond:wght@400;700&display=swap" rel="stylesheet"/>
 
@@ -86,8 +88,31 @@
 .footbar{position:fixed;right:12px;bottom:8px;display:flex;gap:8px;align-items:center;z-index:25}
 .footbtn{padding:6px 8px;border:1px solid var(--border);border-radius:10px;background:var(--chip);cursor:pointer;font-size:14px}
 </style>
+<script type="module" src="/app.js"></script>
 </head>
 <body>
+<header class="dev-shell-header" role="banner">
+  <div class="dev-shell-inner">
+    <div class="dev-shell-title" aria-live="polite">
+      <span id="devShellProduct" class="dev-shell-product">ScribeCat</span>
+      <span id="devShellVersion" class="dev-shell-version">0.1.0</span>
+    </div>
+    <ul class="dev-shell-status" aria-live="polite">
+      <li class="dev-shell-status-item">
+        <span class="dev-shell-status-label">Internet</span>
+        <span id="statusInternet" class="dev-shell-status-value is-warn">checking…</span>
+      </li>
+      <li class="dev-shell-status-item">
+        <span class="dev-shell-status-label">Static Server</span>
+        <span id="statusStatic" class="dev-shell-status-value is-warn">checking…</span>
+      </li>
+      <li class="dev-shell-status-item">
+        <span class="dev-shell-status-label">App</span>
+        <span id="statusApp" class="dev-shell-status-value is-warn">loading…</span>
+      </li>
+    </ul>
+  </div>
+</header>
 <div class="topbar">
   <div class="inner container">
     <div class="titlewrap">

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,129 @@
+:root {
+  color-scheme: light dark;
+  --dev-shell-font: "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+  --dev-shell-bg: rgba(255, 255, 255, 0.82);
+  --dev-shell-border: rgba(15, 23, 42, 0.12);
+  --dev-shell-text: #111827;
+  --dev-shell-muted: #6b7280;
+  --dev-shell-chip-bg: rgba(148, 163, 184, 0.16);
+  --dev-shell-chip-border: rgba(148, 163, 184, 0.35);
+  --dev-shell-ok: #16a34a;
+  --dev-shell-warn: #f59e0b;
+  --dev-shell-bad: #dc2626;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --dev-shell-bg: rgba(15, 23, 42, 0.7);
+    --dev-shell-border: rgba(148, 163, 184, 0.3);
+    --dev-shell-text: #e2e8f0;
+    --dev-shell-muted: #94a3b8;
+    --dev-shell-chip-bg: rgba(51, 65, 85, 0.65);
+    --dev-shell-chip-border: rgba(148, 163, 184, 0.45);
+  }
+}
+
+.dev-shell-header {
+  background: var(--dev-shell-bg);
+  border-bottom: 1px solid var(--dev-shell-border);
+  backdrop-filter: blur(6px);
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  padding: 0.65rem 1rem;
+  font-family: var(--dev-shell-font);
+  color: var(--dev-shell-text);
+}
+
+.dev-shell-inner {
+  margin: 0 auto;
+  max-width: 960px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.dev-shell-title {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.dev-shell-product {
+  letter-spacing: 0.01em;
+}
+
+.dev-shell-version {
+  color: var(--dev-shell-muted);
+  font-size: 0.85rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.dev-shell-status {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.dev-shell-status-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.4rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  border: 1px solid var(--dev-shell-chip-border);
+  background: var(--dev-shell-chip-bg);
+  font-size: 0.75rem;
+  letter-spacing: 0.01em;
+}
+
+.dev-shell-status-label {
+  color: var(--dev-shell-muted);
+}
+
+.dev-shell-status-value {
+  font-weight: 600;
+  transition: color 0.2s ease;
+}
+
+.dev-shell-status-value.is-ok {
+  color: var(--dev-shell-ok);
+}
+
+.dev-shell-status-value.is-warn {
+  color: var(--dev-shell-warn);
+}
+
+.dev-shell-status-value.is-bad {
+  color: var(--dev-shell-bad);
+}
+
+@supports not ((backdrop-filter: blur(6px))) {
+  .dev-shell-header {
+    background: linear-gradient(
+      to bottom,
+      rgba(255, 255, 255, 0.9) 0%,
+      rgba(255, 255, 255, 0.8) 70%,
+      rgba(255, 255, 255, 0.75) 100%
+    );
+  }
+
+  @media (prefers-color-scheme: dark) {
+    .dev-shell-header {
+      background: linear-gradient(
+        to bottom,
+        rgba(15, 23, 42, 0.85) 0%,
+        rgba(15, 23, 42, 0.78) 70%,
+        rgba(15, 23, 42, 0.72) 100%
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a lightweight dev shell header that surfaces the product name/version plus connection status chips
- style the header for both light/dark backgrounds and expose a small status script that checks connectivity and readiness
- generate `web/version.json` in `scripts/start_static.sh` before the static server comes up so the header can show the configured version

## Testing
- `node scripts/fetch_assets.mjs && bash scripts/ensure_icon.sh`
- `bash scripts/start_static.sh && curl -sI http://localhost:1420/ | head -n 1`
- `npx tauri info`
- `npx tauri dev` *(fails: missing glib-2.0 / webkit2gtk prerequisites on runner)*

------
https://chatgpt.com/codex/tasks/task_e_68cbeb618d8c832d96eec3e91e3f4d46