### PR TITLE
Add release automation scripts and document packaged workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,10 @@ logs/
 *.dSYM/
 *.app
 *.app/
+
+# Release packaging outputs
+/target/
+/src-tauri/target/
+/dist/
+/backups/*.orig
+*.dSYM

--- a/README.md
+++ b/README.md
@@ -57,9 +57,50 @@ backups/                logs, plans, results
 6. End Session to push any local tweaks and open a final PR
 
 ## Dev vs Prod
-- The status overlay appears in the lower-right corner to show product version, git branch/SHA, and health checks. Toggle it at any time with <kbd>Cmd/Ctrl</kbd> + <kbd>`</kbd>, force it on with `?status=1` in the URL, or persist your preference via `localStorage.setItem("scribecat:statusVisible", "true" | "false")`.
-- During development `SHOW_STATUS_OVERLAY` defaults to `1` (visible); set `SHOW_STATUS_OVERLAY=0` before running `scripts/start_static.sh` or the dev helper scripts to hide it by default in packaged builds.
-- Build the desktop bundle with `bash scripts/build_app.sh`. The script fetches assets, injects git metadata, and runs `npx tauri build`; outputs land in `dist/` and remain untracked in git.
+- Development serves the UI from `http://localhost:1420` through `scripts/start_static.sh` or the dev helpers in `scripts/dev.sh`; the static server should keep running while you iterate.
+- Packaged releases ship the same assets inside the `.app` bundle, so no static server is required when you launch the desktop app.
+- The status overlay is available in both environments. It is visible by default while developing on `localhost`, starts hidden in packaged builds, and can always be toggled with <kbd>Cmd/Ctrl</kbd> + <kbd>`</kbd> or forced on with `?status=1`. The preference persists via `localStorage.setItem("scribecat:statusVisible", "true" | "false")`.
+- Override the default during local testing by exporting `SHOW_STATUS_OVERLAY=0` before running `scripts/start_static.sh`.
+
+## Prod (Packaged) App
+1. **Build** – `bash scripts/release_build.sh`
+   - Fetches runtime assets (best effort), regenerates the icon, ensures `web/version.json`, injects git metadata, runs `npx tauri info`, and then `npx tauri build`. The script restores `web/index.html` on exit so the working tree stays clean and defaults the packaged overlay to hidden.
+2. **Stage** – `bash scripts/release_stage.sh`
+   - Copies `target/release/bundle/macos/ScribeCat.app` into `~/Applications/ScribeCat.app`. Use `--dry-run` to preview the paths without copying (helpful on non-macOS hosts or CI).
+3. **Open** – `bash scripts/release_open.sh`
+   - Launches the staged bundle, falling back to the freshly built output. `--dry-run` prints the path it would open.
+
+- Build outputs stay in `target/`/`dist/` and the staged app lives in `~/Applications`; `.gitignore` prevents committing bundles or backups.
+- In the packaged app the status overlay defaults to hidden until toggled via the hotkey or query flag; the visibility persists between launches.
+
+### Desktop shortcuts
+Create a macOS launcher on the Desktop so non-terminal users can reopen the packaged app quickly:
+
+```bash
+cat <<'EOF' > "$HOME/Desktop/ScribeCat Open Release.command"
+#!/usr/bin/env bash
+set -euo pipefail
+cd /path/to/your/ScribeCat/checkout
+bash scripts/release_open.sh
+EOF
+chmod +x "$HOME/Desktop/ScribeCat Open Release.command"
+```
+
+An optional builder shortcut can chain the scripts:
+
+```bash
+cat <<'EOF' > "$HOME/Desktop/ScribeCat Build Release.command"
+#!/usr/bin/env bash
+set -euo pipefail
+cd /path/to/your/ScribeCat/checkout
+bash scripts/release_build.sh
+bash scripts/release_stage.sh
+bash scripts/release_open.sh
+EOF
+chmod +x "$HOME/Desktop/ScribeCat Build Release.command"
+```
+
+Both commands keep binaries outside the repo—only the Desktop helpers are created locally.
 
 ## Assets Policy
 No binaries or build artifacts in git. If assets are required, add entries to `scripts/assets.manifest.json` and let `scripts/fetch_assets.mjs` download at runtime.

--- a/scripts/release_build.sh
+++ b/scripts/release_build.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+STATIC_PID_FILE="$ROOT_DIR/backups/static_server.pid"
+index_modified=0
+
+cleanup() {
+  local status=$?
+
+  if [[ -f "$STATIC_PID_FILE" ]]; then
+    local pid
+    pid=$(cat "$STATIC_PID_FILE" 2>/dev/null || echo "")
+    if [[ -n "$pid" ]]; then
+      if ps -p "$pid" >/dev/null 2>&1; then
+        kill "$pid" >/dev/null 2>&1 || true
+        wait "$pid" 2>/dev/null || true
+      fi
+    fi
+    rm -f "$STATIC_PID_FILE"
+  fi
+
+  if [[ $index_modified -eq 1 ]]; then
+    bash "$SCRIPT_DIR/status_meta.sh" --restore >/dev/null 2>&1 || true
+  fi
+
+  trap - EXIT
+  exit $status
+}
+trap cleanup EXIT
+
+cd "$ROOT_DIR"
+
+echo "release_build: fetching external assets (best effort)"
+node "$SCRIPT_DIR/fetch_assets.mjs" || true
+
+echo "release_build: ensuring application icon"
+bash "$SCRIPT_DIR/ensure_icon.sh"
+
+echo "release_build: preparing static bundle"
+SHOW_STATUS_OVERLAY="${SHOW_STATUS_OVERLAY:-0}" bash "$SCRIPT_DIR/start_static.sh"
+
+echo "release_build: embedding git metadata"
+bash "$SCRIPT_DIR/status_meta.sh"
+index_modified=1
+
+echo "release_build: collecting tauri info"
+npx tauri info
+
+echo "release_build: building packaged application"
+npx tauri build
+
+APP_BUNDLE="$ROOT_DIR/target/release/bundle/macos/ScribeCat.app"
+if [[ -d "$APP_BUNDLE" ]]; then
+  echo "release_build: bundle available at $APP_BUNDLE"
+else
+  echo "release_build: warning - bundle not found at $APP_BUNDLE" >&2
+fi

--- a/scripts/release_open.sh
+++ b/scripts/release_open.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+APP_NAME="ScribeCat.app"
+STAGED_APP="$HOME/Applications/$APP_NAME"
+BUILT_APP="$ROOT_DIR/target/release/bundle/macos/$APP_NAME"
+DRY_RUN=0
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=1
+  shift
+fi
+
+preferred_path="$STAGED_APP"
+fallback_path="$BUILT_APP"
+
+if [[ -d "$preferred_path" ]]; then
+  APP_PATH="$preferred_path"
+elif [[ -d "$fallback_path" ]]; then
+  APP_PATH="$fallback_path"
+else
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "release_open: (dry-run) would prefer $preferred_path (not found)" >&2
+    echo "release_open: (dry-run) fallback path $fallback_path (not found)" >&2
+    exit 0
+  fi
+  echo "release_open: no app bundle found (checked $preferred_path and $fallback_path)" >&2
+  exit 1
+fi
+
+echo "release_open: using $APP_PATH"
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  exit 0
+fi
+
+if ! command -v open >/dev/null 2>&1; then
+  echo "release_open: 'open' command not available; this script requires macOS" >&2
+  exit 1
+fi
+
+open "$APP_PATH"

--- a/scripts/release_stage.sh
+++ b/scripts/release_stage.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+APP_NAME="ScribeCat.app"
+SOURCE_BUNDLE="$ROOT_DIR/target/release/bundle/macos/$APP_NAME"
+DEST_DIR="$HOME/Applications"
+DEST_BUNDLE="$DEST_DIR/$APP_NAME"
+DRY_RUN=0
+
+if [[ "${1:-}" == "--dry-run" ]]; then
+  DRY_RUN=1
+  shift
+fi
+
+if [[ -d "$SOURCE_BUNDLE" ]]; then
+  echo "release_stage: staging $SOURCE_BUNDLE -> $DEST_BUNDLE"
+else
+  if [[ $DRY_RUN -eq 1 ]]; then
+    echo "release_stage: (dry-run) expected bundle at $SOURCE_BUNDLE" >&2
+    echo "release_stage: (dry-run) would copy to $DEST_BUNDLE"
+    exit 0
+  fi
+  echo "release_stage: missing bundle at $SOURCE_BUNDLE" >&2
+  exit 1
+fi
+
+if [[ $DRY_RUN -eq 1 ]]; then
+  echo "release_stage: (dry-run) would copy to $DEST_BUNDLE"
+  exit 0
+fi
+
+OS_NAME="$(uname -s 2>/dev/null || echo unknown)"
+if [[ "$OS_NAME" != "Darwin" ]]; then
+  echo "release_stage: staging requires macOS (detected $OS_NAME)" >&2
+  exit 1
+fi
+
+mkdir -p "$DEST_DIR"
+
+if command -v rsync >/dev/null 2>&1; then
+  rm -rf "$DEST_BUNDLE"
+  rsync -a "$SOURCE_BUNDLE" "$DEST_DIR/"
+else
+  rm -rf "$DEST_BUNDLE"
+  cp -R "$SOURCE_BUNDLE" "$DEST_BUNDLE"
+fi
+
+echo "release_stage: staged app to $DEST_BUNDLE"

--- a/scripts/status_meta.sh
+++ b/scripts/status_meta.sh
@@ -23,9 +23,7 @@ if [[ ! -f "$INDEX_FILE" ]]; then
 fi
 
 mkdir -p "$BACKUP_DIR"
-if [[ ! -f "$BACKUP_FILE" ]]; then
-  cp "$INDEX_FILE" "$BACKUP_FILE"
-fi
+cp "$INDEX_FILE" "$BACKUP_FILE"
 
 branch=$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
 sha=$(git -C "$ROOT_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")

--- a/web/status.js
+++ b/web/status.js
@@ -133,6 +133,22 @@ function determineHealthUrl() {
   }
 }
 
+function determineDefaultVisibility() {
+  try {
+    const { protocol, hostname, port } = window.location;
+    if (protocol === "http:" || protocol === "https:") {
+      const localHosts = ["localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"];
+      if (localHosts.includes(hostname)) {
+        return true;
+      }
+      if (port && Number.parseInt(port, 10) === 1420) {
+        return true;
+      }
+    }
+  } catch {}
+  return false;
+}
+
 function formatTimeString(date) {
   if (!(date instanceof Date) || Number.isNaN(date.getTime())) return { text: "—", iso: "" };
   return { text: date.toLocaleTimeString(), iso: date.toISOString() };
@@ -152,6 +168,7 @@ export function initStatusOverlay(options = {}) {
   let visible = false;
   let healthTimer = null;
   const healthUrl = determineHealthUrl();
+  const envDefaultVisible = determineDefaultVisibility();
 
   function updateVisibility(next, opts = {}) {
     const shouldPersist = opts.persist ?? true;
@@ -245,6 +262,8 @@ export function initStatusOverlay(options = {}) {
     updateVisibility(forced, { persist: true });
   } else if (stored !== null) {
     updateVisibility(stored, { persist: false });
+  } else {
+    updateVisibility(envDefaultVisible, { persist: false });
   }
 
   (async () => {
@@ -257,20 +276,20 @@ export function initStatusOverlay(options = {}) {
         const name = data.productName || data.name || DEFAULT_PRODUCT.name;
         const version = data.version || DEFAULT_PRODUCT.version;
         elements.productEl.textContent = `${name}@${version}`;
-        const defaultVisible = normalizeShowFlag(data.showStatusOverlay, true);
+        const defaultVisible = normalizeShowFlag(data.showStatusOverlay, envDefaultVisible);
         if (forced === null && stored === null) {
           updateVisibility(defaultVisible, { persist: false });
         }
       } else {
         elements.productEl.textContent = `${DEFAULT_PRODUCT.name}@${DEFAULT_PRODUCT.version}`;
         if (forced === null && stored === null) {
-          updateVisibility(true, { persist: false });
+          updateVisibility(envDefaultVisible, { persist: false });
         }
       }
     } catch {
       elements.productEl.textContent = `${DEFAULT_PRODUCT.name}@${DEFAULT_PRODUCT.version}`;
       if (forced === null && stored === null) {
-        updateVisibility(true, { persist: false });
+        updateVisibility(envDefaultVisible, { persist: false });
       }
     }
   })();


### PR DESCRIPTION
## Summary
- add release_build/release_stage/release_open automation and refresh the git metadata helper so release builds stay clean
- adjust the status overlay to derive sensible defaults for dev versus packaged origins while keeping overrides intact
- extend docs and helper ignore patterns so packaged artifacts stay outside the repo

## Rationale
Promotes the project from dev-only usage to a reproducible packaged macOS app while preserving the status overlay UX and keeping build products out of git.

## Testing
- `node scripts/fetch_assets.mjs && bash scripts/ensure_icon.sh`
- `bash scripts/start_static.sh && curl -sI http://localhost:1420/ | head -n 1`
- `bash scripts/release_stage.sh --dry-run`
- `bash scripts/release_open.sh --dry-run`
- `npx tauri info` *(warns about missing webkit2gtk-4.1 & rsvg2 in the container)*

## Risks
- Release scripts assume macOS tooling (`open`, `rsync`) is available when staging or launching the bundle.
- Overlay defaults rely on URL heuristics; unusual hosting setups may need to override via `SHOW_STATUS_OVERLAY`.

## Rollback
Revert the three commits to drop the release scripts, README copy, and .gitignore additions, then restore the previous overlay behavior and status_meta backup logic.

------
https://chatgpt.com/codex/tasks/task_e_68cc76fca044832d9dbc57086c2ca125