### PR TITLE
feat: audio recorder with transcription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,7 @@ logs/
 /dist/
 /backups/*.orig
 *.dSYM
+/web/.runtime/
+/tmp/*.wav
+/tmp/*.ogg
+/tmp/*.webm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 0.2.0 - 2025-09-18
+### Added
+- Recording and transcription support in the dashboard recorder panel.
+
+### Changed
+- Status overlay hooks to surface recording state without interrupting existing health signals.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ bash scripts/dev_sync.sh
 bash scripts/dev_end.sh
 ```
 
+- Run `node scripts/env_inject.mjs` to expose `ASSEMBLYAI_API_KEY` to the web runtime, then launch the dev console at http://localhost:1420 and use the recording pill to capture audio notes.
+
+## Features
+- Status overlay that tracks connectivity, static server health, and bundle metadata.
+- Built-in audio recorder with VU meter, elapsed timer, and safe download links.
+- Optional AssemblyAI transcription when the `ASSEMBLYAI_API_KEY` environment variable is present.
+
 ## Environment
 Secrets are never committed. Provide through your platform’s secret manager or local env:
 - MAKE_WEBHOOK_URL

--- a/scripts/env_inject.mjs
+++ b/scripts/env_inject.mjs
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const rootDir = path.resolve(__dirname, "..");
+const runtimeDir = path.join(rootDir, "web", ".runtime");
+
+const apiKey = (process.env.ASSEMBLYAI_API_KEY || "").trim();
+
+const envObject = {};
+if (apiKey) {
+  envObject.AAI = apiKey;
+}
+
+const contents = `window.SC_ENV = Object.assign({}, window.SC_ENV || {}, ${JSON.stringify(envObject)});\n`;
+
+async function main() {
+  await mkdir(runtimeDir, { recursive: true });
+  await writeFile(path.join(runtimeDir, "env.js"), contents, "utf8");
+  if (apiKey) {
+    console.log("AssemblyAI key injected into web/.runtime/env.js");
+  } else {
+    console.log("Generated web/.runtime/env.js without AssemblyAI key (not provided).");
+  }
+}
+
+main().catch((error) => {
+  console.error("Failed to inject runtime environment", error);
+  process.exitCode = 1;
+});

--- a/scripts/start_static.sh
+++ b/scripts/start_static.sh
@@ -21,7 +21,7 @@ const path = require("path");
 
 const CONFIG_PATH = path.join("src-tauri", "tauri.conf.json");
 let productName = "ScribeCat";
-let version = "0.1.0";
+let version = "0.2.0";
 
 try {
   const raw = fs.readFileSync(CONFIG_PATH, "utf8");

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2753,7 +2753,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scribecat"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "tauri",
  "tauri-build",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scribecat"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 [dependencies]
 tauri = { version = "2.8.5", features = [] }

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>ScribeCat records audio notes when you use the recorder.</string>
+  </dict>
+</plist>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "identifier": "com.scribecat.app",
   "productName": "ScribeCat",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "build": {
     "beforeDevCommand": "node scripts/fetch_assets.mjs && bash scripts/start_static.sh",
     "devUrl": "http://localhost:1420",

--- a/web/app.js
+++ b/web/app.js
@@ -1,7 +1,10 @@
 import { initHotkeysModal } from "./hotkeys.js";
 import { initStatusOverlay } from "./status.js";
+import { createAudioRecorder } from "./recorder.js";
+import { createTranscriber } from "./transcribe.js";
 
-const DEFAULT_PRODUCT = { name: "ScribeCat", version: "0.1.0" };
+const DEFAULT_PRODUCT = { name: "ScribeCat", version: "0.2.0" };
+const env = (window.SC_ENV = window.SC_ENV || {});
 const THEME_STORAGE_KEY = "scribe-theme";
 const LOG_LIMIT = 60;
 const ROUTES = new Set(["dashboard", "logs", "about"]);
@@ -20,6 +23,7 @@ let hotkeysController = null;
 let hasExplicitTheme = false;
 let currentTheme = "light";
 let currentProduct = { ...DEFAULT_PRODUCT };
+let overlayController = null;
 
 function formatConsoleArguments(args) {
   return args
@@ -80,6 +84,24 @@ function renderLogs() {
 function scrollLogsToBottom() {
   if (!logListEl) return;
   logListEl.scrollTop = logListEl.scrollHeight;
+}
+
+function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms <= 0) return "00:00";
+  const totalSeconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+}
+
+function formatSize(bytes) {
+  if (!Number.isFinite(bytes) || bytes <= 0) return "0.00 MB";
+  const megabytes = bytes / (1024 * 1024);
+  if (megabytes >= 0.1) {
+    return `${megabytes.toFixed(2)} MB`;
+  }
+  const kilobytes = bytes / 1024;
+  return `${kilobytes.toFixed(1)} KB`;
 }
 
 function addLogEntry(level, message) {
@@ -345,6 +367,515 @@ function handleKeydown(event) {
   }
 }
 
+function inferExtension(mimeType) {
+  if (typeof mimeType !== "string" || mimeType.length === 0) return "ogg";
+  if (mimeType.includes("wav")) return "wav";
+  if (mimeType.includes("ogg")) return "ogg";
+  if (mimeType.includes("webm")) return "webm";
+  if (mimeType.includes("mp4")) return "m4a";
+  return "ogg";
+}
+
+function initRecorderPanel() {
+  const recorderRoot = document.querySelector("[data-recorder]");
+  if (!recorderRoot) return;
+
+  const transcriptRoot = document.querySelector("[data-transcript]");
+  const captionEl = recorderRoot.querySelector("[data-recorder-caption]");
+  const dotEl = recorderRoot.querySelector("[data-recorder-dot]");
+  const timerEl = recorderRoot.querySelector("[data-recorder-timer]");
+  const sizeEl = recorderRoot.querySelector("[data-recorder-size]");
+  const meterEl = recorderRoot.querySelector("[data-recorder-meter]");
+  const errorEl = recorderRoot.querySelector("[data-recorder-error]");
+  const audioEl = recorderRoot.querySelector("[data-recorder-audio]");
+  const downloadEl = recorderRoot.querySelector("[data-recorder-download]");
+  const transcriptStatusEl = transcriptRoot?.querySelector("[data-transcript-status]") || null;
+  const transcriptOutputEl = transcriptRoot?.querySelector("[data-transcript-output]") || null;
+
+  const buttonsByAction = new Map();
+  recorderRoot.querySelectorAll("[data-recorder-action]").forEach((button) => {
+    const action = button.getAttribute("data-recorder-action");
+    if (!buttonsByAction.has(action)) {
+      buttonsByAction.set(action, []);
+    }
+    buttonsByAction.get(action).push(button);
+  });
+
+  const transcriber = createTranscriber({ apiKey: env.AAI });
+  const recorder = createAudioRecorder({
+    maxBytes: 30 * 1024 * 1024,
+    onMeter(level) {
+      updateMeter(level);
+    },
+    onElapsed(ms) {
+      timerEl.textContent = formatDuration(ms);
+      current.durationMs = ms;
+    },
+    onStateChange(details) {
+      handleRecorderState(details || {});
+    },
+    onError(error) {
+      handleRecorderError(error);
+    },
+  });
+
+  if (!recorder || !recorder.isSupported()) {
+    disableAllButtons();
+    setRecorderUiState("error", {
+      message: "Audio recording is not supported in this browser.",
+      overlayState: "error",
+    });
+    return;
+  }
+
+  const current = {
+    blob: null,
+    url: null,
+    extension: "ogg",
+    durationMs: 0,
+    size: 0,
+    mimeType: "",
+  };
+
+  let isPlaying = false;
+  let transcribeAbort = null;
+
+  if (audioEl) {
+    audioEl.addEventListener("play", () => {
+      isPlaying = true;
+      updatePlayButtons();
+    });
+    audioEl.addEventListener("pause", () => {
+      isPlaying = false;
+      updatePlayButtons();
+    });
+    audioEl.addEventListener("ended", () => {
+      isPlaying = false;
+      updatePlayButtons();
+    });
+  }
+
+  function updateOverlayMic(state) {
+    if (!overlayController || typeof overlayController.setMicState !== "function") return;
+    try {
+      overlayController.setMicState(state);
+    } catch (err) {
+      console.warn("Failed to sync microphone state", err);
+    }
+  }
+
+  function setRecorderUiState(state, options = {}) {
+    const { message, overlayState } = options;
+    recorderRoot.dataset.recorderState = state;
+    if (captionEl && typeof message === "string") {
+      captionEl.textContent = message;
+    }
+    const dotState =
+      overlayState ||
+      (state === "recording"
+        ? "recording"
+        : state === "processing"
+        ? "processing"
+        : state === "transcribed"
+        ? "transcribed"
+        : state === "error"
+        ? "error"
+        : "idle");
+    if (dotEl) {
+      dotEl.dataset.state = dotState;
+    }
+    updateOverlayMic(dotState);
+  }
+
+  function updateMeter(level) {
+    const normalized = Math.min(Math.max(Number(level) || 0, 0), 1);
+    if (meterEl) {
+      meterEl.style.setProperty("--recorder-meter-level", normalized.toFixed(3));
+    }
+  }
+
+  function updatePlayButtons() {
+    const label = isPlaying ? "Pause" : "Play";
+    (buttonsByAction.get("play") || []).forEach((button) => {
+      button.textContent = label;
+    });
+  }
+
+  function setButtonDisabled(action, disabled) {
+    (buttonsByAction.get(action) || []).forEach((button) => {
+      button.disabled = disabled;
+    });
+  }
+
+  function disableAllButtons() {
+    buttonsByAction.forEach((buttonList) => {
+      buttonList.forEach((button) => {
+        button.disabled = true;
+      });
+    });
+  }
+
+  function clearError() {
+    if (errorEl) {
+      errorEl.textContent = "";
+    }
+  }
+
+  function showError(message) {
+    if (errorEl) {
+      errorEl.textContent = message;
+    }
+  }
+
+  function handleRecorderError(error) {
+    const message = typeof error === "string" ? error : error?.message || "Recording failed.";
+    showError(message);
+    setRecorderUiState("error", { message, overlayState: "error" });
+    addLogEntry("error", `Recorder error (${message}).`);
+    setButtonDisabled("record", false);
+    setButtonDisabled("stop", true);
+    setButtonDisabled("play", true);
+    setButtonDisabled("save", true);
+    setButtonDisabled("clear", false);
+    setButtonDisabled("transcribe", true);
+    updateMeter(0);
+  }
+
+  function revokeObjectUrl() {
+    if (current.url) {
+      URL.revokeObjectURL(current.url);
+      current.url = null;
+    }
+  }
+
+  function attachAudio(blob) {
+    if (!audioEl || !blob) return;
+    revokeObjectUrl();
+    const url = URL.createObjectURL(blob);
+    current.url = url;
+    audioEl.src = url;
+    audioEl.hidden = false;
+    try {
+      audioEl.load();
+    } catch {}
+    updatePlayButtons();
+  }
+
+  function clearAudio() {
+    if (!audioEl) return;
+    try {
+      audioEl.pause();
+    } catch {}
+    audioEl.hidden = true;
+    audioEl.removeAttribute("src");
+    try {
+      audioEl.load();
+    } catch {}
+    isPlaying = false;
+    updatePlayButtons();
+  }
+
+  function cancelTranscription(message) {
+    if (transcribeAbort) {
+      transcribeAbort.abort();
+      transcribeAbort = null;
+      if (transcriptStatusEl && message) {
+        transcriptStatusEl.textContent = message;
+      }
+    }
+  }
+
+  function resetState() {
+    cancelTranscription("Transcription reset.");
+    clearAudio();
+    revokeObjectUrl();
+    current.blob = null;
+    current.durationMs = 0;
+    current.size = 0;
+    current.mimeType = "";
+    current.extension = "ogg";
+    timerEl.textContent = "00:00";
+    sizeEl.textContent = "0.00 MB";
+    updateMeter(0);
+    clearError();
+    if (transcriptOutputEl) {
+      transcriptOutputEl.textContent = "";
+    }
+    if (transcriptStatusEl) {
+      transcriptStatusEl.textContent = transcriber.hasApiKey
+        ? "Set up a recording to transcribe."
+        : "Set ASSEMBLYAI_API_KEY to enable transcription.";
+    }
+    setRecorderUiState("idle", { message: "Ready to capture audio.", overlayState: "idle" });
+    setButtonDisabled("record", false);
+    setButtonDisabled("stop", true);
+    setButtonDisabled("play", true);
+    setButtonDisabled("save", true);
+    setButtonDisabled("clear", true);
+    setButtonDisabled("transcribe", true);
+  }
+
+  function handleRecorderState(details) {
+    const state = details.state;
+    switch (state) {
+      case "requesting": {
+        clearError();
+        setRecorderUiState("active", { message: "Requesting microphone access…" });
+        setButtonDisabled("record", true);
+        setButtonDisabled("stop", true);
+        setButtonDisabled("play", true);
+        setButtonDisabled("save", true);
+        setButtonDisabled("clear", true);
+        setButtonDisabled("transcribe", true);
+        cancelTranscription("Recording in progress.");
+        break;
+      }
+      case "recording": {
+        setRecorderUiState("recording", { message: "Recording…" });
+        clearError();
+        cancelTranscription("Recording in progress.");
+        setButtonDisabled("record", true);
+        setButtonDisabled("stop", false);
+        setButtonDisabled("play", true);
+        setButtonDisabled("save", true);
+        setButtonDisabled("clear", true);
+        setButtonDisabled("transcribe", true);
+        addLogEntry("info", "Recording started.");
+        break;
+      }
+      case "finalizing": {
+        setRecorderUiState("processing", { message: "Processing audio…" });
+        setButtonDisabled("record", true);
+        setButtonDisabled("stop", true);
+        setButtonDisabled("play", true);
+        setButtonDisabled("save", true);
+        setButtonDisabled("clear", true);
+        setButtonDisabled("transcribe", true);
+        break;
+      }
+      case "ready": {
+        current.blob = details.blob || null;
+        current.size = details.bytes ?? (current.blob ? current.blob.size : 0);
+        current.durationMs = details.duration ?? current.durationMs;
+        current.mimeType = details.mimeType || (current.blob ? current.blob.type : "");
+        current.extension = details.extension || inferExtension(current.mimeType);
+        timerEl.textContent = formatDuration(current.durationMs);
+        sizeEl.textContent = formatSize(current.size);
+        updateMeter(0);
+        if (details.notice) {
+          showError(details.notice);
+          addLogEntry("warn", details.notice);
+        } else {
+          clearError();
+        }
+        if (current.blob) {
+          attachAudio(current.blob);
+        }
+        const canTranscribe = Boolean(current.blob) && transcriber.hasApiKey;
+        if (transcriptOutputEl && !current.blob) {
+          transcriptOutputEl.textContent = "";
+        }
+        if (transcriptStatusEl) {
+          transcriptStatusEl.textContent = canTranscribe
+            ? "Ready to transcribe."
+            : transcriber.hasApiKey
+              ? "Record audio to enable transcription."
+              : "Set ASSEMBLYAI_API_KEY to enable transcription.";
+        }
+        setRecorderUiState("active", { message: "Recording ready." });
+        setButtonDisabled("record", false);
+        setButtonDisabled("stop", true);
+        setButtonDisabled("play", !current.blob);
+        setButtonDisabled("save", !current.blob);
+        setButtonDisabled("clear", !current.blob);
+        setButtonDisabled("transcribe", !canTranscribe);
+        addLogEntry("info", "Recording ready.");
+        break;
+      }
+      case "idle": {
+        resetState();
+        break;
+      }
+      case "error": {
+        handleRecorderError(details.error);
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  function ensureRecordingStopped() {
+    if (recorder.isRecording()) {
+      recorder.stop().catch(() => {});
+    }
+  }
+
+  async function startRecording() {
+    clearError();
+    cancelTranscription("Recording in progress.");
+    try {
+      await recorder.start();
+    } catch (error) {
+      const message = error?.message || "Failed to start recording.";
+      handleRecorderError(message);
+      addLogEntry("error", `Failed to start recording (${message}).`);
+    }
+  }
+
+  async function stopRecording() {
+    if (!recorder.isRecording()) return;
+    try {
+      await recorder.stop();
+      addLogEntry("info", "Recording stopped.");
+    } catch (error) {
+      const message = error?.message || "Failed to stop recording.";
+      handleRecorderError(message);
+      addLogEntry("error", `Failed to stop recording (${message}).`);
+    }
+  }
+
+  async function togglePlayback() {
+    if (!audioEl || !current.url) return;
+    try {
+      if (audioEl.paused) {
+        await audioEl.play();
+      } else {
+        audioEl.pause();
+      }
+    } catch (error) {
+      const message = error?.message || "Unable to play recording.";
+      showError(message);
+      addLogEntry("warn", `Playback failed (${message}).`);
+    }
+  }
+
+  function saveRecording() {
+    if (!current.blob || !current.url || !downloadEl) return;
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const extension = current.extension || inferExtension(current.mimeType);
+    const filename = `scribecat-${timestamp}.${extension}`;
+    downloadEl.href = current.url;
+    downloadEl.download = filename;
+    downloadEl.click();
+    addLogEntry("info", `Recording saved (${filename}).`);
+  }
+
+  function clearRecordingAction() {
+    cancelTranscription("Transcription reset.");
+    recorder.reset();
+    resetState();
+    addLogEntry("info", "Recorder reset.");
+  }
+
+  function setTranscribeBusy(active) {
+    const buttons = buttonsByAction.get("transcribe") || [];
+    buttons.forEach((button) => {
+      button.disabled = active || !current.blob || !transcriber.hasApiKey;
+      button.textContent = active ? "Transcribing…" : "Transcribe";
+    });
+    setButtonDisabled("record", active);
+    setButtonDisabled("stop", true);
+  }
+
+  async function runTranscription() {
+    if (!transcriber.hasApiKey) {
+      showError("AssemblyAI API key is not configured.");
+      return;
+    }
+    if (!current.blob) {
+      showError("Record audio before requesting a transcript.");
+      return;
+    }
+    cancelTranscription();
+    transcribeAbort = new AbortController();
+    setTranscribeBusy(true);
+    setRecorderUiState("processing", {
+      message: "Submitting for transcription…",
+      overlayState: "processing",
+    });
+    if (transcriptOutputEl) {
+      transcriptOutputEl.textContent = "";
+    }
+    if (transcriptStatusEl) {
+      transcriptStatusEl.textContent = "Uploading audio…";
+    }
+    try {
+      const result = await transcriber.transcribe(current.blob, {
+        signal: transcribeAbort.signal,
+        onStatus(status) {
+          if (status?.message && transcriptStatusEl) {
+            transcriptStatusEl.textContent = status.message;
+          }
+        },
+      });
+      if (transcriptOutputEl) {
+        const text = (result?.text || "").trim();
+        transcriptOutputEl.textContent = text.length > 0 ? text : "(No transcript returned.)";
+      }
+      if (transcriptStatusEl) {
+        transcriptStatusEl.textContent = "Transcription completed.";
+      }
+      setRecorderUiState("transcribed", { message: "Transcript ready.", overlayState: "transcribed" });
+      addLogEntry("info", "Transcription completed.");
+    } catch (error) {
+      if (error?.name === "AbortError") {
+        if (transcriptStatusEl) {
+          transcriptStatusEl.textContent = "Transcription canceled.";
+        }
+        addLogEntry("warn", "Transcription canceled.");
+      } else {
+        const message = error?.message || "Transcription failed.";
+        showError(message);
+        if (transcriptStatusEl) {
+          transcriptStatusEl.textContent = message;
+        }
+        addLogEntry("error", `Transcription failed (${message}).`);
+      }
+      setRecorderUiState("active", { message: "Recording ready." });
+    } finally {
+      setTranscribeBusy(false);
+      transcribeAbort = null;
+      setButtonDisabled("transcribe", !current.blob || !transcriber.hasApiKey);
+    }
+  }
+
+  (buttonsByAction.get("record") || []).forEach((button) => {
+    button.addEventListener("click", startRecording);
+  });
+  (buttonsByAction.get("stop") || []).forEach((button) => {
+    button.addEventListener("click", stopRecording);
+  });
+  (buttonsByAction.get("play") || []).forEach((button) => {
+    button.addEventListener("click", togglePlayback);
+  });
+  (buttonsByAction.get("save") || []).forEach((button) => {
+    button.addEventListener("click", saveRecording);
+  });
+  (buttonsByAction.get("clear") || []).forEach((button) => {
+    button.addEventListener("click", clearRecordingAction);
+  });
+  (buttonsByAction.get("transcribe") || []).forEach((button) => {
+    button.addEventListener("click", runTranscription);
+  });
+
+  if (!transcriber.hasApiKey) {
+    setButtonDisabled("transcribe", true);
+    if (transcriptStatusEl) {
+      transcriptStatusEl.textContent = "Set ASSEMBLYAI_API_KEY to enable transcription.";
+    }
+  }
+
+  resetState();
+
+  window.addEventListener("beforeunload", () => {
+    cancelTranscription();
+    ensureRecordingStopped();
+    recorder.reset();
+    revokeObjectUrl();
+  });
+}
+
 document.addEventListener("DOMContentLoaded", () => {
   appShellEl = document.querySelector(".app-shell");
   themeToggleBtn = document.getElementById("themeToggle");
@@ -396,6 +927,7 @@ document.addEventListener("DOMContentLoaded", () => {
   loadVersion();
 
   if (typeof initStatusOverlay === "function") {
-    initStatusOverlay({ rootId: "status-root" });
+    overlayController = initStatusOverlay({ rootId: "status-root" }) || null;
   }
+  initRecorderPanel();
 });

--- a/web/index.html
+++ b/web/index.html
@@ -3,9 +3,23 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <meta name="git" content="branch=unknown;sha=unknown" />
+  <meta name="git" content="branch=work;sha=ac6938c" />
   <title>ScribeCat Dev Console</title>
   <link rel="stylesheet" href="./style.css" />
+  <script>
+    window.SC_ENV = window.SC_ENV || {};
+    try {
+      const script = document.createElement("script");
+      script.src = "./.runtime/env.js";
+      script.defer = true;
+      script.onerror = () => {
+        console.info("No runtime env file found; transcription will remain disabled until the key is provided.");
+      };
+      document.head.appendChild(script);
+    } catch (error) {
+      console.info("Failed to prime runtime env", error);
+    }
+  </script>
 </head>
 <body>
   <div class="app-shell" data-route="dashboard">
@@ -13,7 +27,7 @@
       <div class="brand">
         <div class="brand-title">
           <span class="brand-name" id="productName">ScribeCat</span>
-          <span class="brand-version" id="productVersion">0.1.0</span>
+          <span class="brand-version" id="productVersion">0.2.0</span>
         </div>
         <span class="badge-dev" role="status" aria-live="polite">DEV BUILD</span>
       </div>
@@ -64,6 +78,50 @@
               <p class="status-meta">Last updated: <time data-status-time>never</time></p>
             </article>
           </div>
+          <section class="recorder-panel" data-recorder data-recorder-state="idle">
+            <div class="recorder-summary">
+              <span class="recorder-dot" data-recorder-dot aria-hidden="true"></span>
+              <div class="recorder-summary-text">
+                <span class="recorder-summary-title">Recorder</span>
+                <span class="recorder-summary-caption" data-recorder-caption>Ready to capture audio.</span>
+              </div>
+              <button type="button" class="recorder-button recorder-button--primary" data-recorder-action="record">Record</button>
+            </div>
+            <div class="recorder-body">
+              <div class="recorder-display">
+                <span class="recorder-timer" data-recorder-timer>00:00</span>
+                <span class="recorder-size" data-recorder-size>0.00 MB</span>
+                <div class="recorder-meter" aria-hidden="true">
+                  <div class="recorder-meter-bar" data-recorder-meter></div>
+                </div>
+              </div>
+              <div class="recorder-actions">
+                <button type="button" class="recorder-button" data-recorder-action="stop" disabled>Stop</button>
+                <button type="button" class="recorder-button" data-recorder-action="play" disabled>Play</button>
+                <button type="button" class="recorder-button" data-recorder-action="save" disabled>Save</button>
+                <button type="button" class="recorder-button" data-recorder-action="clear" disabled>Clear</button>
+                <button
+                  type="button"
+                  class="recorder-button"
+                  data-recorder-action="transcribe"
+                  data-recorder-transcribe
+                  disabled
+                >
+                  Transcribe
+                </button>
+              </div>
+              <div class="recorder-error" data-recorder-error role="status" aria-live="polite"></div>
+              <audio data-recorder-audio hidden controls></audio>
+              <a data-recorder-download hidden download></a>
+            </div>
+          </section>
+          <section class="transcript-panel" data-transcript>
+            <header class="transcript-header">
+              <h2>Transcript</h2>
+              <span class="transcript-status" data-transcript-status>Transcription requires ASSEMBLYAI_API_KEY.</span>
+            </header>
+            <div class="transcript-body" data-transcript-output aria-live="polite"></div>
+          </section>
           <section class="log-panel" id="logPanel" aria-live="polite">
             <header class="log-header">
               <h2>Recent Logs</h2>

--- a/web/recorder.js
+++ b/web/recorder.js
@@ -1,0 +1,380 @@
+const MIME_PREFERENCE = [
+  { type: "audio/ogg;codecs=opus", extension: "ogg" },
+  { type: "audio/webm;codecs=opus", extension: "webm" },
+  { type: "audio/webm", extension: "webm" },
+  { type: "audio/wav", extension: "wav" },
+];
+
+function selectMimeType() {
+  if (typeof window === "undefined" || typeof window.MediaRecorder === "undefined") {
+    return { type: "audio/webm", extension: "webm" };
+  }
+  for (const candidate of MIME_PREFERENCE) {
+    if (typeof window.MediaRecorder.isTypeSupported === "function") {
+      try {
+        if (window.MediaRecorder.isTypeSupported(candidate.type)) {
+          return candidate;
+        }
+      } catch {}
+    }
+  }
+  return { type: "audio/webm", extension: "webm" };
+}
+
+function stopTracks(stream) {
+  if (!stream) return;
+  try {
+    stream.getTracks().forEach((track) => {
+      try {
+        track.stop();
+      } catch {}
+    });
+  } catch {}
+}
+
+export function createAudioRecorder(options = {}) {
+  const supported = Boolean(navigator?.mediaDevices?.getUserMedia) && typeof window.MediaRecorder !== "undefined";
+  const noopRecorder = {
+    isSupported: () => false,
+    isRecording: () => false,
+    async start() {
+      throw new Error("MediaRecorder is not supported in this environment.");
+    },
+    async stop() {
+      throw new Error("MediaRecorder is not supported in this environment.");
+    },
+    reset() {},
+    getBlob() {
+      return null;
+    },
+    getMimeType() {
+      return "";
+    },
+    getExtension() {
+      return "";
+    },
+  };
+
+  if (!supported) {
+    return noopRecorder;
+  }
+
+  const onStateChange = typeof options.onStateChange === "function" ? options.onStateChange : () => {};
+  const onMeter = typeof options.onMeter === "function" ? options.onMeter : () => {};
+  const onElapsed = typeof options.onElapsed === "function" ? options.onElapsed : () => {};
+  const onError = typeof options.onError === "function" ? options.onError : () => {};
+  const maxBytes = Number.isFinite(options.maxBytes) ? Number(options.maxBytes) : 30 * 1024 * 1024;
+  const timeslice = Number.isFinite(options.timeslice) ? Number(options.timeslice) : 500;
+
+  let state = "idle";
+  let mediaStream = null;
+  let mediaRecorder = null;
+  let audioContext = null;
+  let sourceNode = null;
+  let analyserNode = null;
+  let analyserBuffer = null;
+  let rafId = null;
+  let startTimestamp = 0;
+  let durationMs = 0;
+  let recordedBlob = null;
+  let mimeType = "";
+  let extension = "";
+  let totalBytes = 0;
+  let sizeLimitHit = false;
+  let sizeLimitMessage = "";
+  let stopPromise = null;
+  let stopResolve = null;
+  let stopReject = null;
+
+  const chunks = [];
+
+  function setState(next, payload = {}) {
+    state = next;
+    try {
+      onStateChange({ state: next, ...payload });
+    } catch (error) {
+      console.warn("Recorder state listener failed", error);
+    }
+  }
+
+  function cleanupNodes() {
+    if (rafId) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    onMeter(0);
+    if (sourceNode) {
+      try {
+        sourceNode.disconnect();
+      } catch {}
+      sourceNode = null;
+    }
+    if (analyserNode) {
+      try {
+        analyserNode.disconnect();
+      } catch {}
+      analyserNode = null;
+    }
+    if (audioContext) {
+      audioContext.close().catch(() => {});
+      audioContext = null;
+    }
+  }
+
+  function cleanupMedia() {
+    if (mediaRecorder) {
+      mediaRecorder.ondataavailable = null;
+      mediaRecorder.onerror = null;
+      mediaRecorder.onstop = null;
+      try {
+        if (mediaRecorder.state !== "inactive") {
+          mediaRecorder.stop();
+        }
+      } catch {}
+      mediaRecorder = null;
+    }
+    stopTracks(mediaStream);
+    mediaStream = null;
+    cleanupNodes();
+  }
+
+  function resetStopPromise() {
+    stopPromise = null;
+    stopResolve = null;
+    stopReject = null;
+  }
+
+  function ensureStopPromise() {
+    if (!stopPromise) {
+      stopPromise = new Promise((resolve, reject) => {
+        stopResolve = resolve;
+        stopReject = reject;
+      });
+    }
+    return stopPromise;
+  }
+
+  function reportError(error) {
+    const err = error instanceof Error ? error : new Error(typeof error === "string" ? error : "Recording failed.");
+    try {
+      onError(err);
+    } catch (callbackError) {
+      console.warn("Recorder error listener failed", callbackError);
+    }
+    setState("error", { error: err.message });
+  }
+
+  function computeLevel() {
+    if (!analyserNode || !analyserBuffer) return 0;
+    analyserNode.getByteTimeDomainData(analyserBuffer);
+    let sumSquares = 0;
+    for (let i = 0; i < analyserBuffer.length; i += 1) {
+      const deviation = (analyserBuffer[i] - 128) / 128;
+      sumSquares += deviation * deviation;
+    }
+    const rms = Math.sqrt(sumSquares / analyserBuffer.length);
+    return Math.min(1, rms * 1.5);
+  }
+
+  function tick() {
+    if (state !== "recording") return;
+    const level = computeLevel();
+    try {
+      onMeter(level);
+    } catch {}
+    const now = performance.now();
+    durationMs = now - startTimestamp;
+    try {
+      onElapsed(durationMs);
+    } catch {}
+    rafId = requestAnimationFrame(tick);
+  }
+
+  function handleDataAvailable(event) {
+    if (!event?.data || event.data.size === 0) return;
+    chunks.push(event.data);
+    totalBytes += event.data.size;
+    if (maxBytes > 0 && totalBytes >= maxBytes && !sizeLimitHit) {
+      sizeLimitHit = true;
+      const limitMb = (maxBytes / (1024 * 1024)).toFixed(1);
+      sizeLimitMessage = `Recording stopped at ~${limitMb} MB to keep files manageable.`;
+      setState("finalizing");
+      try {
+        mediaRecorder.stop();
+      } catch (error) {
+        reportError(error);
+        stopReject?.(error);
+        resetStopPromise();
+      }
+    }
+  }
+
+  function finalizeRecording() {
+    const selectedType = mimeType || chunks.find((chunk) => chunk.type)?.type || undefined;
+    try {
+      recordedBlob = new Blob(chunks, selectedType ? { type: selectedType } : undefined);
+    } catch (error) {
+      recordedBlob = null;
+      reportError(error);
+      stopReject?.(error);
+      resetStopPromise();
+      return;
+    }
+    const payload = {
+      blob: recordedBlob,
+      bytes: recordedBlob ? recordedBlob.size : 0,
+      duration: durationMs,
+      mimeType: recordedBlob?.type || selectedType || "",
+      extension,
+      notice: sizeLimitHit && sizeLimitMessage ? sizeLimitMessage : undefined,
+    };
+    setState("ready", payload);
+    sizeLimitHit = false;
+    sizeLimitMessage = "";
+    stopResolve?.(recordedBlob);
+    resetStopPromise();
+  }
+
+  function handleStop() {
+    cleanupNodes();
+    stopTracks(mediaStream);
+    mediaStream = null;
+    mediaRecorder = null;
+    finalizeRecording();
+  }
+
+  function handleRecorderError(event) {
+    const error = event?.error instanceof Error ? event.error : new Error("Recording failed.");
+    cleanupMedia();
+    reportError(error);
+    stopReject?.(error);
+    resetStopPromise();
+  }
+
+  async function start() {
+    if (state === "recording") {
+      throw new Error("Recording already in progress.");
+    }
+    chunks.length = 0;
+    totalBytes = 0;
+    recordedBlob = null;
+    mimeType = "";
+    extension = "";
+    durationMs = 0;
+    sizeLimitHit = false;
+    sizeLimitMessage = "";
+
+    setState("requesting");
+    try {
+      mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    } catch (error) {
+      reportError(error);
+      throw error;
+    }
+
+    const selected = selectMimeType();
+    mimeType = selected.type;
+    extension = selected.extension;
+
+    try {
+      audioContext = new (window.AudioContext || window.webkitAudioContext)();
+      sourceNode = audioContext.createMediaStreamSource(mediaStream);
+      analyserNode = audioContext.createAnalyser();
+      analyserNode.fftSize = 2048;
+      analyserBuffer = new Uint8Array(analyserNode.fftSize);
+      sourceNode.connect(analyserNode);
+    } catch (error) {
+      cleanupMedia();
+      reportError(error);
+      throw error;
+    }
+
+    try {
+      mediaRecorder = new MediaRecorder(mediaStream, mimeType ? { mimeType } : undefined);
+    } catch (error) {
+      cleanupMedia();
+      reportError(error);
+      throw error;
+    }
+
+    mediaRecorder.addEventListener("dataavailable", handleDataAvailable);
+    mediaRecorder.addEventListener("stop", handleStop);
+    mediaRecorder.addEventListener("error", handleRecorderError);
+
+    try {
+      mediaRecorder.start(timeslice);
+    } catch (error) {
+      cleanupMedia();
+      reportError(error);
+      throw error;
+    }
+
+    startTimestamp = performance.now();
+    setState("recording");
+    onMeter(0);
+    onElapsed(0);
+    rafId = requestAnimationFrame(tick);
+    return true;
+  }
+
+  async function stop() {
+    if (state === "idle" || state === "ready") {
+      return recordedBlob;
+    }
+    if (state === "error") {
+      return recordedBlob;
+    }
+    const promise = ensureStopPromise();
+    if (state === "recording") {
+      setState("finalizing");
+      try {
+        mediaRecorder.stop();
+      } catch (error) {
+        cleanupMedia();
+        reportError(error);
+        stopReject?.(error);
+        resetStopPromise();
+        throw error;
+      }
+    } else if (state === "finalizing") {
+      // Already stopping; wait for promise.
+    } else if (state === "requesting") {
+      cleanupMedia();
+      setState("idle");
+      stopResolve?.(null);
+      resetStopPromise();
+      return null;
+    }
+    return promise;
+  }
+
+  function reset() {
+    cleanupMedia();
+    chunks.length = 0;
+    totalBytes = 0;
+    recordedBlob = null;
+    mimeType = "";
+    extension = "";
+    durationMs = 0;
+    sizeLimitHit = false;
+    sizeLimitMessage = "";
+    if (state !== "idle") {
+      setState("idle");
+    }
+  }
+
+  return {
+    isSupported: () => true,
+    isRecording: () => state === "recording",
+    async start() {
+      return start();
+    },
+    async stop() {
+      return stop();
+    },
+    reset,
+    getBlob: () => recordedBlob,
+    getMimeType: () => mimeType,
+    getExtension: () => extension,
+  };
+}

--- a/web/status.js
+++ b/web/status.js
@@ -1,4 +1,4 @@
-const DEFAULT_PRODUCT = { name: "ScribeCat", version: "0.1.0" };
+const DEFAULT_PRODUCT = { name: "ScribeCat", version: "0.2.0" };
 const STORAGE_KEY = "scribecat:statusVisible";
 const QUERY_KEY = "status";
 const HEALTH_INTERVAL_MS = 30000;
@@ -98,6 +98,17 @@ function createOverlay(root) {
 
   healthRow.append(dotEl, labelEl);
 
+  const micRow = document.createElement("div");
+  micRow.className = "status-overlay__mic";
+  const micDot = document.createElement("span");
+  micDot.className = "status-overlay__mic-dot";
+  micDot.dataset.state = "idle";
+  micDot.setAttribute("aria-hidden", "true");
+  const micLabel = document.createElement("span");
+  micLabel.className = "status-overlay__mic-label";
+  micLabel.textContent = "Mic idle";
+  micRow.append(micDot, micLabel);
+
   const timeRow = document.createElement("div");
   timeRow.className = "status-overlay__time";
   const timePrefix = document.createElement("span");
@@ -108,7 +119,7 @@ function createOverlay(root) {
   timeEl.textContent = "—";
   timeRow.append(timePrefix, document.createTextNode(" "), timeEl);
 
-  container.append(metaRow, healthRow, timeRow);
+  container.append(metaRow, healthRow, micRow, timeRow);
   root.appendChild(container);
 
   return {
@@ -117,6 +128,8 @@ function createOverlay(root) {
     gitEl,
     dotEl,
     labelEl,
+    micDot,
+    micLabel,
     timeEl,
   };
 }
@@ -169,6 +182,28 @@ export function initStatusOverlay(options = {}) {
   let healthTimer = null;
   const healthUrl = determineHealthUrl();
   const envDefaultVisible = determineDefaultVisibility();
+  const micLabels = {
+    idle: "Mic idle",
+    recording: "Recording…",
+    processing: "Transcribing…",
+    transcribed: "Transcript ready",
+    error: "Mic error",
+  };
+  const allowedMicStates = new Set(["idle", "recording", "processing", "transcribed", "error"]);
+  let micState = "idle";
+
+  function setMicState(state, message) {
+    const nextState = allowedMicStates.has(state) ? state : "idle";
+    micState = nextState;
+    if (elements.micDot) {
+      elements.micDot.dataset.state = nextState;
+    }
+    if (elements.micLabel) {
+      const fallback = micLabels[nextState] || micLabels.idle;
+      const text = typeof message === "string" && message.trim().length > 0 ? message : fallback;
+      elements.micLabel.textContent = text;
+    }
+  }
 
   function updateVisibility(next, opts = {}) {
     const shouldPersist = opts.persist ?? true;
@@ -295,4 +330,11 @@ export function initStatusOverlay(options = {}) {
   })();
 
   startHealthPolling();
+  setMicState("idle");
+
+  return {
+    setMicState,
+    updateVisibility,
+    getMicState: () => micState,
+  };
 }

--- a/web/style.css
+++ b/web/style.css
@@ -726,3 +726,244 @@ kbd {
 .status-overlay__time-value {
   font-variant-numeric: tabular-nums;
 }
+
+[data-recorder] {
+  position: relative;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: 1rem 1.25rem;
+  box-shadow: var(--shadow-soft);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  display: grid;
+  gap: 0.75rem;
+}
+
+[data-recorder][data-recorder-state="idle"] {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  max-width: 360px;
+}
+
+[data-recorder][data-recorder-state="idle"] .recorder-body {
+  display: none;
+}
+
+[data-recorder][data-recorder-state="recording"] {
+  border-color: var(--status-error);
+  box-shadow: 0 0 0 3px rgba(199, 66, 66, 0.18);
+}
+
+[data-recorder][data-recorder-state="processing"] {
+  border-color: var(--status-checking);
+}
+
+[data-recorder][data-recorder-state="transcribed"] {
+  border-color: var(--status-ok);
+}
+
+[data-recorder][data-recorder-state="error"] {
+  border-color: var(--status-error);
+  box-shadow: 0 0 0 3px rgba(199, 66, 66, 0.18);
+}
+
+.recorder-summary {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+[data-recorder-dot] {
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: var(--color-muted);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.08);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+[data-recorder][data-recorder-state="recording"] [data-recorder-dot] {
+  background: var(--status-error);
+  transform: scale(1.1);
+}
+
+[data-recorder][data-recorder-state="processing"] [data-recorder-dot] {
+  background: var(--status-checking);
+}
+
+[data-recorder][data-recorder-state="transcribed"] [data-recorder-dot] {
+  background: var(--status-ok);
+}
+
+.recorder-summary-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.recorder-summary-caption {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.recorder-body {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.recorder-display {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.recorder-timer {
+  font-family: "Roboto Mono", "SFMono-Regular", Menlo, monospace;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.recorder-size {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.recorder-meter {
+  flex: 1 1 160px;
+  position: relative;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--color-surface-subtle);
+  overflow: hidden;
+}
+
+.recorder-meter-bar {
+  --recorder-meter-level: 0;
+  width: calc(var(--recorder-meter-level) * 100%);
+  max-width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, var(--status-checking), var(--status-error));
+  transition: width 0.12s ease;
+}
+
+.recorder-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.recorder-button {
+  min-width: 90px;
+  padding: 0.45rem 0.95rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+  font-weight: 600;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.recorder-button:not(:disabled):hover {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #ffffff;
+}
+
+.recorder-button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.recorder-button--primary {
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+  color: #ffffff;
+}
+
+.recorder-button--primary:disabled {
+  opacity: 0.6;
+}
+
+.recorder-button:focus-visible {
+  outline: 3px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.recorder-error {
+  min-height: 1.2rem;
+  font-size: 0.85rem;
+  color: var(--status-error);
+}
+
+.transcript-panel {
+  margin-top: var(--gap-md);
+  padding: 1rem 1.25rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-soft);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.transcript-header {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.transcript-header h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.transcript-status {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.transcript-body {
+  max-height: 240px;
+  overflow-y: auto;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.status-overlay__mic {
+  margin-top: 0.5rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+}
+
+.status-overlay__mic-dot {
+  width: 0.5rem;
+  height: 0.5rem;
+  border-radius: 50%;
+  background: var(--color-muted);
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.12);
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.status-overlay__mic-dot[data-state="recording"] {
+  background: var(--status-error);
+  transform: scale(1.1);
+}
+
+.status-overlay__mic-dot[data-state="processing"] {
+  background: var(--status-checking);
+}
+
+.status-overlay__mic-dot[data-state="transcribed"] {
+  background: var(--status-ok);
+}
+
+.status-overlay__mic-dot[data-state="error"] {
+  background: var(--status-error);
+  box-shadow: 0 0 0 2px rgba(199, 66, 66, 0.3);
+}
+

--- a/web/transcribe.js
+++ b/web/transcribe.js
@@ -1,0 +1,125 @@
+const UPLOAD_URL = "https://api.assemblyai.com/v2/upload";
+const TRANSCRIPT_URL = "https://api.assemblyai.com/v2/transcript";
+const POLL_INTERVAL_MS = 2000;
+const MAX_POLL_ATTEMPTS = 60;
+
+function delay(ms, signal) {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException("The operation was aborted.", "AbortError"));
+      return;
+    }
+    const timeout = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    function onAbort() {
+      clearTimeout(timeout);
+      signal?.removeEventListener("abort", onAbort);
+      reject(new DOMException("The operation was aborted.", "AbortError"));
+    }
+    if (signal) {
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}
+
+function emitStatus(callback, stage, message) {
+  if (typeof callback === "function") {
+    try {
+      callback({ stage, message });
+    } catch (error) {
+      console.warn("Transcription status listener failed", error);
+    }
+  }
+}
+
+async function uploadAudio(fetchImpl, blob, headers, signal, onStatus) {
+  emitStatus(onStatus, "uploading", "Uploading audio…");
+  const response = await fetchImpl(UPLOAD_URL, {
+    method: "POST",
+    headers: {
+      ...headers,
+      "Content-Type": "application/octet-stream",
+    },
+    body: blob,
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`Upload failed (HTTP ${response.status})`);
+  }
+  const data = await response.json();
+  if (!data?.upload_url) {
+    throw new Error("AssemblyAI did not return an upload URL.");
+  }
+  return data.upload_url;
+}
+
+async function requestTranscript(fetchImpl, audioUrl, headers, signal, onStatus) {
+  emitStatus(onStatus, "queued", "Requesting transcription…");
+  const response = await fetchImpl(TRANSCRIPT_URL, {
+    method: "POST",
+    headers: {
+      ...headers,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ audio_url: audioUrl }),
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`Failed to request transcript (HTTP ${response.status})`);
+  }
+  const data = await response.json();
+  if (!data?.id) {
+    throw new Error("AssemblyAI did not return a transcript id.");
+  }
+  return data.id;
+}
+
+async function pollTranscript(fetchImpl, transcriptId, headers, signal, onStatus) {
+  const statusUrl = `${TRANSCRIPT_URL}/${encodeURIComponent(transcriptId)}`;
+  for (let attempt = 0; attempt < MAX_POLL_ATTEMPTS; attempt += 1) {
+    emitStatus(onStatus, "processing", "Transcribing audio…");
+    const response = await fetchImpl(statusUrl, { headers, signal });
+    if (!response.ok) {
+      throw new Error(`Polling failed (HTTP ${response.status})`);
+    }
+    const data = await response.json();
+    if (data?.status === "completed") {
+      emitStatus(onStatus, "completed", "Transcription completed.");
+      return data;
+    }
+    if (data?.status === "error") {
+      const message = data?.error || "AssemblyAI reported an error.";
+      throw new Error(message);
+    }
+    await delay(POLL_INTERVAL_MS, signal);
+  }
+  throw new Error("Transcription timed out. Try again with a shorter clip.");
+}
+
+export function createTranscriber(options = {}) {
+  const rawKey = typeof options.apiKey === "string" ? options.apiKey.trim() : "";
+  const fetchImpl = typeof options.fetch === "function" ? options.fetch : typeof options.fetchImpl === "function" ? options.fetchImpl : fetch;
+  const apiKey = rawKey;
+  const hasApiKey = apiKey.length > 0;
+
+  async function transcribe(blob, config = {}) {
+    if (!hasApiKey) {
+      throw new Error("AssemblyAI API key is not configured.");
+    }
+    if (!(blob instanceof Blob) || blob.size === 0) {
+      throw new Error("Audio blob is empty.");
+    }
+    const signal = config.signal;
+    const onStatus = config.onStatus;
+    const headers = { Authorization: apiKey };
+    emitStatus(onStatus, "starting", "Preparing transcript request…");
+    const audioUrl = await uploadAudio(fetchImpl, blob, headers, signal, onStatus);
+    const transcriptId = await requestTranscript(fetchImpl, audioUrl, headers, signal, onStatus);
+    const result = await pollTranscript(fetchImpl, transcriptId, headers, signal, onStatus);
+    return { id: transcriptId, text: result?.text || "", raw: result };
+  }
+
+  return { hasApiKey, transcribe };
+}


### PR DESCRIPTION
## Summary
- bump the desktop bundle to 0.2.0 and document the release
- add MediaRecorder-based capture with optional AssemblyAI polling plus status overlay wiring
- document the new recorder workflow and env injection helper in the README

## Testing
- `node scripts/fetch_assets.mjs && bash scripts/ensure_icon.sh`
- `bash scripts/start_static.sh && curl -sI http://localhost:1420/ | head -n 1`
- `node scripts/env_inject.mjs`
- `npx tauri info`
- `npx tauri dev`

## Risks
- MediaRecorder/AssemblyAI support differs across browsers; ensure fallback messaging is acceptable.

## Rollback
- Revert the three commits or run `git revert` per commit to disable the recorder/transcriber additions and restore 0.1.0 metadata.


------
https://chatgpt.com/codex/tasks/task_e_68cc89f2f210832db6325d0889c86bb9