### PR TITLE
Add AssemblyAI transcription, recorder settings, and command palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ bash scripts/dev_end.sh
 - **Inject the dev key** – export `ASSEMBLYAI_API_KEY` in your shell and run `node scripts/env_inject.mjs`. The script writes `web/.runtime/env.js`, which is ignored by git, and merges the key into `window.SC_ENV.AAI` for the browser runtime.
 - **Privacy** – recordings stay local until you click **Transcribe**. When the key is present the clip uploads directly to AssemblyAI’s `/v2/upload` endpoint; keep that in mind before sending sensitive audio.
 - **Recorder workflow** – Record ⟶ Stop ⟶ optionally Play/Save the `.webm`/`.ogg` output ⟶ Transcribe when the button is visible. Without a key the button is hidden and the action bar shows a tooltip (`Transcription unavailable in prod without proxy.`) as a reminder that the dev adapter is disabled.
+- **Recorder settings drawer** – Click the gear in the header (or press <kbd>Cmd/Ctrl</kbd> + <kbd>,</kbd>) to toggle preferences. Auto-open transcript is enabled by default; auto-save downloads the clip automatically to your browser’s default Downloads folder and stays disabled until you opt in.
+- **Command palette** – Press <kbd>Cmd/Ctrl</kbd> + <kbd>K</kbd> or use the ⌘K button to search for recorder actions, open settings, rerun checks, or jump to the shortcut reference without leaving the keyboard.
 - **Status overlay** – Toggle visibility with <kbd>Cmd/Ctrl</kbd> + <kbd>`</kbd>. Click the bottom-right chevron to collapse into a pill that only shows the health dot. The collapsed state persists via `localStorage.setItem("scribecat:statusCollapsed", "1" | "0")`.
 
 ### Troubleshooting

--- a/scripts/env_inject.mjs
+++ b/scripts/env_inject.mjs
@@ -9,15 +9,19 @@ const rootDir = path.resolve(__dirname, "..");
 const runtimeDir = path.join(rootDir, "web", ".runtime");
 
 const apiKey = (process.env.ASSEMBLYAI_API_KEY || "").trim();
+const stage = (process.env.SCRIBECAT_ENV || process.env.NODE_ENV || "development").toLowerCase();
+const allowSecretInjection = stage !== "production";
 
-const contents = apiKey
+const contents = allowSecretInjection && apiKey
   ? `window.SC_ENV = Object.assign({}, window.SC_ENV || {}, { AAI: ${JSON.stringify(apiKey)} });\n`
   : "window.SC_ENV = window.SC_ENV || {};\n";
 
 async function main() {
   await mkdir(runtimeDir, { recursive: true });
   await writeFile(path.join(runtimeDir, "env.js"), contents, "utf8");
-  if (apiKey) {
+  if (apiKey && !allowSecretInjection) {
+    console.warn("Skipping AssemblyAI key injection outside dev environment (SCRIBECAT_ENV/ NODE_ENV indicates production).");
+  } else if (apiKey) {
     console.log("AssemblyAI key injected into web/.runtime/env.js");
   } else {
     console.log("Generated web/.runtime/env.js without AssemblyAI key (not provided).");

--- a/web/app.js
+++ b/web/app.js
@@ -2,12 +2,138 @@ import { initHotkeysModal } from "./hotkeys.js";
 import { initStatusOverlay } from "./status.js";
 import { createAudioRecorder } from "./recorder.js";
 import { createTranscriber } from "./transcribe.js";
+import { initCommandPalette } from "./commands.js";
 
 const DEFAULT_PRODUCT = { name: "ScribeCat", version: "0.2.0" };
 const env = (window.SC_ENV = window.SC_ENV || {});
 const THEME_STORAGE_KEY = "scribe-theme";
 const LOG_LIMIT = 60;
 const ROUTES = new Set(["dashboard", "logs", "about"]);
+
+const SETTINGS_STORAGE_KEY = "scribecat:recorderSettings";
+const DEFAULT_SETTINGS = {
+  autoOpenTranscript: true,
+  autoSaveRecording: false,
+};
+
+const settingsListeners = new Set();
+const commandSources = new Map();
+
+function normalizeSettings(value = {}) {
+  return {
+    autoOpenTranscript: value.autoOpenTranscript !== false,
+    autoSaveRecording: Boolean(value.autoSaveRecording),
+  };
+}
+
+function readStoredSettings() {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return null;
+    }
+    const raw = window.localStorage.getItem(SETTINGS_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    return normalizeSettings({ ...DEFAULT_SETTINGS, ...parsed });
+  } catch (error) {
+    console.warn("Failed to read recorder settings", error);
+    return null;
+  }
+}
+
+let settingsState = normalizeSettings({ ...DEFAULT_SETTINGS, ...(readStoredSettings() || {}) });
+
+function getSettingsSnapshot() {
+  return { ...settingsState };
+}
+
+function persistSettingsState(next) {
+  try {
+    if (typeof window !== "undefined" && window.localStorage) {
+      window.localStorage.setItem(SETTINGS_STORAGE_KEY, JSON.stringify(next));
+    }
+  } catch (error) {
+    console.warn("Failed to persist recorder settings", error);
+  }
+}
+
+function notifySettingsListeners() {
+  const snapshot = getSettingsSnapshot();
+  settingsListeners.forEach((listener) => {
+    try {
+      listener(snapshot);
+    } catch (error) {
+      console.warn("Recorder settings listener failed", error);
+    }
+  });
+}
+
+function setSetting(key, value) {
+  if (!(key in DEFAULT_SETTINGS)) return;
+  const normalized = key === "autoOpenTranscript" ? value !== false : Boolean(value);
+  if (settingsState[key] === normalized) return;
+  settingsState = { ...settingsState, [key]: normalized };
+  persistSettingsState(settingsState);
+  notifySettingsListeners();
+}
+
+function subscribeSettings(listener) {
+  if (typeof listener !== "function") {
+    return () => {};
+  }
+  settingsListeners.add(listener);
+  try {
+    listener(getSettingsSnapshot());
+  } catch (error) {
+    console.warn("Recorder settings listener failed", error);
+  }
+  return () => {
+    settingsListeners.delete(listener);
+  };
+}
+
+function getSettingValue(key) {
+  return settingsState[key];
+}
+
+function registerCommandSource(key, supplier) {
+  if (!key || typeof supplier !== "function") {
+    return () => {};
+  }
+  commandSources.set(key, supplier);
+  refreshCommandPalette();
+  return () => {
+    if (commandSources.get(key) === supplier) {
+      commandSources.delete(key);
+      refreshCommandPalette();
+    }
+  };
+}
+
+function collectCommandsFromSources() {
+  const commands = [];
+  commandSources.forEach((supplier) => {
+    try {
+      const result = supplier();
+      if (Array.isArray(result)) {
+        commands.push(...result);
+      }
+    } catch (error) {
+      console.warn("Command palette source failed", error);
+    }
+  });
+  return commands;
+}
+
+function refreshCommandPalette() {
+  if (!commandPaletteController || typeof commandPaletteController.setCommands !== "function") {
+    return;
+  }
+  const commands = collectCommandsFromSources();
+  commandPaletteController.setCommands(commands);
+}
 
 const logEntries = [];
 const statusTargets = new Map();
@@ -20,6 +146,8 @@ let logFallbackEl = null;
 let appShellEl = null;
 let themeToggleBtn = null;
 let hotkeysController = null;
+let commandPaletteController = null;
+let settingsDrawerController = null;
 let hasExplicitTheme = false;
 let currentTheme = "light";
 let currentProduct = { ...DEFAULT_PRODUCT };
@@ -112,6 +240,7 @@ function addLogEntry(level, message) {
     logEntries.splice(0, logEntries.length - LOG_LIMIT);
   }
   renderLogs();
+  refreshCommandPalette();
 }
 
 function clearLogs() {
@@ -318,6 +447,184 @@ function toggleTheme() {
   hasExplicitTheme = true;
   localStorage.setItem(THEME_STORAGE_KEY, next);
   applyTheme(next);
+  refreshCommandPalette();
+}
+
+function initSettingsDrawer(root = document) {
+  const drawer = root.querySelector("[data-settings-drawer]");
+  const trigger = root.getElementById("settingsButton");
+  if (!drawer) {
+    if (trigger) {
+      trigger.setAttribute("hidden", "hidden");
+      trigger.setAttribute("aria-hidden", "true");
+    }
+    return null;
+  }
+
+  const doc = drawer.ownerDocument || root;
+  const panel = drawer.querySelector(".settings-drawer__panel");
+  const backdrop = drawer.querySelector(".settings-drawer__backdrop");
+  const closeButtons = Array.from(drawer.querySelectorAll("[data-settings-close]"));
+  const toggles = Array.from(drawer.querySelectorAll("[data-setting-toggle]"));
+
+  if (panel && !panel.hasAttribute("tabindex")) {
+    panel.setAttribute("tabindex", "-1");
+  }
+
+  drawer.hidden = true;
+  drawer.classList.remove("is-open");
+  drawer.setAttribute("aria-hidden", "true");
+  if (trigger) {
+    trigger.setAttribute("aria-expanded", "false");
+    trigger.setAttribute("aria-haspopup", "dialog");
+  }
+
+  let isOpen = false;
+  let lastFocused = null;
+  let previousBodyOverflow = null;
+
+  function focusElement(element) {
+    if (!element || typeof element.focus !== "function") return;
+    try {
+      element.focus({ preventScroll: true });
+    } catch (error) {
+      element.focus();
+    }
+  }
+
+  function lockScroll() {
+    if (!doc?.body) return;
+    previousBodyOverflow = doc.body.style.overflow;
+    doc.body.style.overflow = "hidden";
+  }
+
+  function unlockScroll() {
+    if (!doc?.body) return;
+    if (previousBodyOverflow != null) {
+      doc.body.style.overflow = previousBodyOverflow;
+    } else {
+      doc.body.style.removeProperty("overflow");
+    }
+    previousBodyOverflow = null;
+  }
+
+  function openDrawer(triggerElement) {
+    if (isOpen) return;
+    const active = doc.activeElement;
+    if (triggerElement instanceof HTMLElement) {
+      lastFocused = triggerElement;
+    } else if (active instanceof HTMLElement) {
+      lastFocused = active;
+    } else {
+      lastFocused = null;
+    }
+    isOpen = true;
+    drawer.hidden = false;
+    drawer.classList.add("is-open");
+    drawer.setAttribute("aria-hidden", "false");
+    if (trigger) {
+      trigger.setAttribute("aria-expanded", "true");
+    }
+    lockScroll();
+    requestAnimationFrame(() => {
+      focusElement(panel || drawer);
+    });
+  }
+
+  function closeDrawer() {
+    if (!isOpen) return;
+    isOpen = false;
+    drawer.classList.remove("is-open");
+    drawer.hidden = true;
+    drawer.setAttribute("aria-hidden", "true");
+    if (trigger) {
+      trigger.setAttribute("aria-expanded", "false");
+    }
+    unlockScroll();
+    const target = lastFocused;
+    lastFocused = null;
+    focusElement(target);
+  }
+
+  function toggleDrawer(force, triggerElement) {
+    if (typeof force === "boolean") {
+      if (force) {
+        openDrawer(triggerElement);
+      } else {
+        closeDrawer();
+      }
+      return isOpen;
+    }
+    if (isOpen) {
+      closeDrawer();
+    } else {
+      openDrawer(triggerElement);
+    }
+    return isOpen;
+  }
+
+  function syncSettings(state = getSettingsSnapshot()) {
+    toggles.forEach((toggle) => {
+      const key = toggle.dataset.settingKey;
+      if (!key) return;
+      const value = state[key];
+      if (key === "autoOpenTranscript") {
+        toggle.checked = value !== false;
+      } else {
+        toggle.checked = Boolean(value);
+      }
+    });
+  }
+
+  const unsubscribe = subscribeSettings(syncSettings);
+
+  toggles.forEach((toggle) => {
+    toggle.addEventListener("change", () => {
+      const key = toggle.dataset.settingKey;
+      if (!key) return;
+      const next = toggle.checked;
+      setSetting(key, next);
+    });
+  });
+
+  if (trigger) {
+    trigger.addEventListener("click", (event) => {
+      event.preventDefault();
+      toggleDrawer(true, trigger);
+    });
+  }
+
+  closeButtons.forEach((button) => {
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      closeDrawer();
+    });
+  });
+
+  if (backdrop) {
+    backdrop.addEventListener("click", () => {
+      closeDrawer();
+    });
+  }
+
+  drawer.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeDrawer();
+    }
+  });
+
+  syncSettings();
+
+  return {
+    open: openDrawer,
+    close: closeDrawer,
+    toggle: toggleDrawer,
+    isOpen: () => isOpen,
+    destroy() {
+      unsubscribe();
+    },
+  };
 }
 
 function isTypingTarget(target) {
@@ -331,6 +638,35 @@ function handleKeydown(event) {
   if (event.defaultPrevented) return;
   const key = event.key;
   const target = event.target;
+  const isModKey = event.metaKey || event.ctrlKey;
+
+  if (commandPaletteController?.isOpen()) {
+    if (key === "Escape") {
+      event.preventDefault();
+      commandPaletteController.close();
+    }
+    return;
+  }
+
+  if (settingsDrawerController?.isOpen() && key === "Escape") {
+    event.preventDefault();
+    settingsDrawerController.close();
+    return;
+  }
+
+  if (isModKey && !event.altKey && !event.shiftKey) {
+    const lowerKey = key.toLowerCase();
+    if (lowerKey === "k" && !isTypingTarget(target)) {
+      event.preventDefault();
+      commandPaletteController?.toggle(true, target instanceof HTMLElement ? target : null);
+      return;
+    }
+    if (key === "," && !isTypingTarget(target)) {
+      event.preventDefault();
+      settingsDrawerController?.toggle(true, target instanceof HTMLElement ? target : null);
+      return;
+    }
+  }
 
   if (key === "?" && !event.repeat && !isTypingTarget(target)) {
     event.preventDefault();
@@ -396,6 +732,9 @@ function initRecorderPanel() {
   const actionsContainer = recorderRoot.querySelector(".recorder-actions");
   const TRANSCRIBE_DISABLED_MESSAGE = "Transcription unavailable in prod without proxy.";
   let transcribeTooltipEl = null;
+  let activeSettings = getSettingsSnapshot();
+  let unsubscribeSettings = null;
+  let unregisterRecorderCommands = () => {};
   recorderRoot.querySelectorAll("[data-recorder-action]").forEach((button) => {
     const action = button.getAttribute("data-recorder-action");
     if (!buttonsByAction.has(action)) {
@@ -431,6 +770,14 @@ function initRecorderPanel() {
     return;
   }
 
+  unsubscribeSettings = subscribeSettings((next) => {
+    activeSettings = next;
+    if (next.autoSaveRecording && current.blob && !current.autoSaved) {
+      maybeAutoSaveRecording();
+    }
+  });
+  unregisterRecorderCommands = registerCommandSource("recorder", buildRecorderCommands);
+
   const current = {
     blob: null,
     url: null,
@@ -438,6 +785,7 @@ function initRecorderPanel() {
     durationMs: 0,
     size: 0,
     mimeType: "",
+    autoSaved: false,
   };
 
   let isPlaying = false;
@@ -455,6 +803,45 @@ function initRecorderPanel() {
     audioEl.addEventListener("ended", () => {
       isPlaying = false;
       updatePlayButtons();
+    });
+  }
+
+  function settingEnabled(key) {
+    const value = activeSettings?.[key];
+    if (key === "autoOpenTranscript") {
+      return value !== false;
+    }
+    return Boolean(value);
+  }
+
+  function refreshRecorderCommands() {
+    refreshCommandPalette();
+  }
+
+  function maybeAutoSaveRecording() {
+    if (!settingEnabled("autoSaveRecording")) return;
+    if (current.autoSaved) return;
+    const saved = performSave({ manual: false });
+    if (saved) {
+      current.autoSaved = true;
+    }
+  }
+
+  function revealTranscriptPanel() {
+    if (!settingEnabled("autoOpenTranscript")) return;
+    const target = transcriptOutputEl || transcriptRoot;
+    if (!target) return;
+    requestAnimationFrame(() => {
+      try {
+        target.scrollIntoView({ behavior: "smooth", block: "center" });
+      } catch {}
+      if (typeof target.focus === "function") {
+        try {
+          target.focus({ preventScroll: true });
+        } catch (error) {
+          target.focus();
+        }
+      }
     });
   }
 
@@ -632,6 +1019,7 @@ function initRecorderPanel() {
       if (transcriptStatusEl && message) {
         transcriptStatusEl.textContent = message;
       }
+      refreshRecorderCommands();
     }
   }
 
@@ -644,6 +1032,7 @@ function initRecorderPanel() {
     current.size = 0;
     current.mimeType = "";
     current.extension = "ogg";
+    current.autoSaved = false;
     timerEl.textContent = "00:00";
     sizeEl.textContent = "0.00 MB";
     updateMeter(0);
@@ -663,6 +1052,7 @@ function initRecorderPanel() {
     setButtonDisabled("save", true);
     setButtonDisabled("clear", true);
     setButtonDisabled("transcribe", true);
+    refreshRecorderCommands();
   }
 
   function handleRecorderState(details) {
@@ -709,6 +1099,7 @@ function initRecorderPanel() {
         current.durationMs = details.duration ?? current.durationMs;
         current.mimeType = details.mimeType || (current.blob ? current.blob.type : "");
         current.extension = details.extension || inferExtension(current.mimeType);
+        current.autoSaved = false;
         timerEl.textContent = formatDuration(current.durationMs);
         sizeEl.textContent = formatSize(current.size);
         updateMeter(0);
@@ -740,6 +1131,7 @@ function initRecorderPanel() {
         setButtonDisabled("clear", !current.blob);
         setButtonDisabled("transcribe", !canTranscribe);
         addLogEntry("info", "Recording ready.");
+        maybeAutoSaveRecording();
         break;
       }
       case "idle": {
@@ -753,6 +1145,7 @@ function initRecorderPanel() {
       default:
         break;
     }
+    refreshRecorderCommands();
   }
 
   function ensureRecordingStopped() {
@@ -800,15 +1193,24 @@ function initRecorderPanel() {
     }
   }
 
-  function saveRecording() {
-    if (!current.blob || !current.url || !downloadEl) return;
+  function performSave(options = {}) {
+    if (!current.blob || !current.url || !downloadEl) return false;
+    const manual = options?.manual !== false;
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
     const extension = current.extension || inferExtension(current.mimeType);
     const filename = `scribecat-${timestamp}.${extension}`;
     downloadEl.href = current.url;
     downloadEl.download = filename;
     downloadEl.click();
-    addLogEntry("info", `Recording saved (${filename}).`);
+    addLogEntry("info", manual ? `Recording saved (${filename}).` : `Recording auto-saved (${filename}).`);
+    return true;
+  }
+
+  function handleSaveClick(event) {
+    if (event instanceof Event) {
+      event.preventDefault();
+    }
+    performSave({ manual: true });
   }
 
   function clearRecordingAction() {
@@ -826,6 +1228,7 @@ function initRecorderPanel() {
     });
     setButtonDisabled("record", active);
     setButtonDisabled("stop", true);
+    refreshRecorderCommands();
   }
 
   async function runTranscription() {
@@ -866,6 +1269,7 @@ function initRecorderPanel() {
       if (transcriptStatusEl) {
         transcriptStatusEl.textContent = "Transcription completed.";
       }
+      revealTranscriptPanel();
       setRecorderUiState("transcribed", { message: "Transcript ready.", overlayState: "transcribed" });
       addLogEntry("info", "Transcription completed.");
     } catch (error) {
@@ -890,6 +1294,101 @@ function initRecorderPanel() {
     }
   }
 
+  function buildRecorderCommands() {
+    const clipReady = Boolean(current.blob);
+    const recording = recorder.isRecording();
+    const transcribing = Boolean(transcribeAbort);
+    const playbackReady = clipReady && audioEl;
+    const playbackPaused = !audioEl || audioEl.paused;
+
+    const commands = [
+      {
+        id: "recorder-start",
+        label: "Start recording",
+        description: "Begin a new clip from the microphone.",
+        keywords: ["record", "start", "microphone"],
+        shortcut: "Record",
+        run: startRecording,
+        isVisible: () => !recording && !transcribing,
+        isEnabled: () => !recording && !transcribing,
+      },
+      {
+        id: "recorder-stop",
+        label: "Stop recording",
+        description: "Finalize the current recording.",
+        keywords: ["stop", "record"],
+        shortcut: "Stop",
+        run: stopRecording,
+        isVisible: () => recording,
+        isEnabled: () => recording,
+      },
+      {
+        id: "recorder-play",
+        label: "Play recording",
+        description: "Listen to the latest clip.",
+        keywords: ["play", "audio", "preview"],
+        shortcut: "Play",
+        run: togglePlayback,
+        isVisible: () => playbackReady && playbackPaused,
+        isEnabled: () => playbackReady,
+      },
+      {
+        id: "recorder-pause",
+        label: "Pause playback",
+        description: "Pause the current playback.",
+        keywords: ["pause", "audio"],
+        shortcut: "Pause",
+        run: togglePlayback,
+        isVisible: () => playbackReady && !playbackPaused,
+        isEnabled: () => playbackReady,
+      },
+      {
+        id: "recorder-save",
+        label: "Save recording",
+        description: "Download the audio file to your device.",
+        keywords: ["save", "download"],
+        shortcut: "Save",
+        run: () => performSave({ manual: true }),
+        isVisible: () => clipReady,
+        isEnabled: () => clipReady,
+      },
+      {
+        id: "recorder-clear",
+        label: "Clear recording",
+        description: "Reset the recorder and remove the current clip.",
+        keywords: ["clear", "reset", "remove"],
+        shortcut: "Clear",
+        run: clearRecordingAction,
+        isVisible: () => clipReady || recording || transcribing,
+        isEnabled: () => !recording && !transcribing,
+      },
+      {
+        id: "recorder-transcribe",
+        label: "Transcribe recording",
+        description: "Send the clip to AssemblyAI for transcription.",
+        keywords: ["transcribe", "assemblyai", "text"],
+        shortcut: "Transcribe",
+        run: runTranscription,
+        isVisible: () => clipReady && transcriber.hasApiKey,
+        isEnabled: () => clipReady && transcriber.hasApiKey && !transcribing,
+      },
+      {
+        id: "recorder-cancel-transcription",
+        label: "Cancel transcription",
+        description: "Abort the active transcription request.",
+        keywords: ["cancel", "abort", "transcribe"],
+        shortcut: "Cancel",
+        run: () => {
+          cancelTranscription("Transcription canceled.");
+        },
+        isVisible: () => transcribing,
+        isEnabled: () => transcribing,
+      },
+    ];
+
+    return commands;
+  }
+
   (buttonsByAction.get("record") || []).forEach((button) => {
     button.addEventListener("click", startRecording);
   });
@@ -900,7 +1399,7 @@ function initRecorderPanel() {
     button.addEventListener("click", togglePlayback);
   });
   (buttonsByAction.get("save") || []).forEach((button) => {
-    button.addEventListener("click", saveRecording);
+    button.addEventListener("click", handleSaveClick);
   });
   (buttonsByAction.get("clear") || []).forEach((button) => {
     button.addEventListener("click", clearRecordingAction);
@@ -926,6 +1425,14 @@ function initRecorderPanel() {
     ensureRecordingStopped();
     recorder.reset();
     revokeObjectUrl();
+    if (typeof unsubscribeSettings === "function") {
+      unsubscribeSettings();
+      unsubscribeSettings = null;
+    }
+    if (typeof unregisterRecorderCommands === "function") {
+      unregisterRecorderCommands();
+      unregisterRecorderCommands = () => {};
+    }
   });
 }
 
@@ -966,6 +1473,71 @@ document.addEventListener("DOMContentLoaded", () => {
     clearBtn.addEventListener("click", clearLogs);
   }
   hotkeysController = initHotkeysModal(document);
+  settingsDrawerController = initSettingsDrawer(document);
+  commandPaletteController = initCommandPalette(document);
+
+  registerCommandSource("core", () => {
+    const settingsButton = document.getElementById("settingsButton");
+    return [
+      {
+        id: "core-open-settings",
+        label: "Open recorder settings",
+        description: "Adjust auto-save and transcript preferences.",
+        keywords: ["settings", "preferences", "drawer"],
+        shortcut: "Cmd/Ctrl+,",
+        run: () => {
+          settingsDrawerController?.toggle(true, settingsButton || null);
+        },
+        isVisible: () => Boolean(settingsDrawerController),
+        isEnabled: () => Boolean(settingsDrawerController),
+      },
+      {
+        id: "core-toggle-theme",
+        label: () => (currentTheme === "dark" ? "Switch to light theme" : "Switch to dark theme"),
+        description: "Toggle between light and dark modes.",
+        keywords: ["theme", "appearance", "light", "dark"],
+        shortcut: "T",
+        run: toggleTheme,
+        isVisible: () => true,
+        isEnabled: () => true,
+      },
+      {
+        id: "core-rerun-checks",
+        label: "Rerun status checks",
+        description: "Ping internet and static server health endpoints.",
+        keywords: ["status", "check", "refresh"],
+        shortcut: "R",
+        run: () => runAllChecks(),
+        isVisible: () => true,
+        isEnabled: () => true,
+      },
+      {
+        id: "core-clear-logs",
+        label: "Clear logs",
+        description: "Remove all entries from the log panel.",
+        keywords: ["logs", "clear"],
+        shortcut: "L",
+        run: clearLogs,
+        isVisible: () => true,
+        isEnabled: () => logEntries.length > 0,
+      },
+      {
+        id: "core-show-hotkeys",
+        label: "Show keyboard shortcuts",
+        description: "Display the shortcut reference overlay.",
+        keywords: ["shortcuts", "help", "keyboard"],
+        shortcut: "?",
+        run: () => {
+          if (hotkeysController) {
+            hotkeysController.open(document.body);
+          }
+        },
+        isVisible: () => Boolean(hotkeysController),
+        isEnabled: () => Boolean(hotkeysController),
+      },
+    ];
+  });
+  refreshCommandPalette();
 
   applyRoute(window.location.hash);
   window.addEventListener("hashchange", () => applyRoute(window.location.hash));

--- a/web/commands.js
+++ b/web/commands.js
@@ -1,0 +1,404 @@
+const noopController = {
+  open() {},
+  close() {},
+  toggle() { return false; },
+  setCommands() {},
+  isOpen() {
+    return false;
+  },
+};
+
+function ensureFocusable(element) {
+  if (element && !element.hasAttribute("tabindex")) {
+    element.setAttribute("tabindex", "-1");
+  }
+}
+
+function normalizeKeywords(value) {
+  if (!value) return "";
+  if (Array.isArray(value)) {
+    return value.join(" ");
+  }
+  return String(value);
+}
+
+function normalizeCommand(command) {
+  const labelGetter =
+    typeof command.label === "function"
+      ? command.label
+      : () => (command.label ? String(command.label) : "Unnamed command");
+  const descriptionGetter =
+    typeof command.description === "function"
+      ? command.description
+      : () => (command.description ? String(command.description) : "");
+  const shortcutGetter =
+    typeof command.shortcut === "function"
+      ? command.shortcut
+      : () => (command.shortcut ? String(command.shortcut) : "");
+  const visibility =
+    typeof command.isVisible === "function"
+      ? command.isVisible
+      : () => command.hidden !== true;
+  const enabled =
+    typeof command.isEnabled === "function"
+      ? command.isEnabled
+      : () => command.disabled !== true;
+  const runner = typeof command.run === "function" ? command.run : () => {};
+  const keywords = normalizeKeywords(command.keywords || command.search).toLowerCase();
+  const baseId = command.id || labelGetter().toLowerCase().replace(/\s+/g, "-");
+
+  return {
+    id: baseId,
+    getLabel: labelGetter,
+    getDescription: descriptionGetter,
+    getShortcut: shortcutGetter,
+    isVisible: visibility,
+    isEnabled: enabled,
+    run: runner,
+    keywords,
+  };
+}
+
+export function initCommandPalette(root = document) {
+  const overlay = root.querySelector("[data-command-palette]");
+  if (!overlay) {
+    return noopController;
+  }
+
+  const doc = overlay.ownerDocument || root;
+  const panel = overlay.querySelector(".command-palette__panel");
+  const backdrop = overlay.querySelector(".command-palette__backdrop");
+  const closeButton = overlay.querySelector("[data-command-close]");
+  const input = overlay.querySelector("[data-command-input]");
+  const list = overlay.querySelector("[data-command-list]");
+  const emptyState = overlay.querySelector("[data-command-empty]");
+  const openers = Array.from(root.querySelectorAll("[data-command-open]"));
+
+  if (input && !input.hasAttribute("aria-expanded")) {
+    input.setAttribute("aria-expanded", "false");
+  }
+
+  ensureFocusable(panel);
+
+  overlay.hidden = true;
+  overlay.classList.remove("is-open");
+  overlay.setAttribute("aria-hidden", "true");
+
+  let isOpen = false;
+  let commands = [];
+  let filtered = [];
+  let activeIndex = -1;
+  let lastTrigger = null;
+  let previousBodyOverflow = null;
+
+  function focusElement(element) {
+    if (!element || typeof element.focus !== "function") return;
+    try {
+      element.focus({ preventScroll: true });
+    } catch (error) {
+      element.focus();
+    }
+  }
+
+  function lockScroll() {
+    if (!doc?.body) return;
+    previousBodyOverflow = doc.body.style.overflow;
+    doc.body.style.overflow = "hidden";
+  }
+
+  function unlockScroll() {
+    if (!doc?.body) return;
+    if (previousBodyOverflow != null) {
+      doc.body.style.overflow = previousBodyOverflow;
+    } else {
+      doc.body.style.removeProperty("overflow");
+    }
+    previousBodyOverflow = null;
+  }
+
+  function getFilterTerm() {
+    return (input?.value || "").trim().toLowerCase();
+  }
+
+  function getActiveCommand() {
+    if (activeIndex < 0 || activeIndex >= filtered.length) return null;
+    return filtered[activeIndex];
+  }
+
+  function updateActiveDescendant() {
+    const options = list?.querySelectorAll("[data-command-index]") || [];
+    options.forEach((option) => {
+      option.classList.remove("is-active");
+      option.setAttribute("aria-selected", "false");
+    });
+    if (activeIndex < 0 || activeIndex >= filtered.length) {
+      if (input) {
+        input.removeAttribute("aria-activedescendant");
+      }
+      return;
+    }
+    const activeOption = list?.querySelector(`[data-command-index="${activeIndex}"]`);
+    if (activeOption) {
+      activeOption.classList.add("is-active");
+      activeOption.setAttribute("aria-selected", "true");
+      if (input) {
+        input.setAttribute("aria-activedescendant", activeOption.id);
+      }
+      activeOption.scrollIntoView({ block: "nearest" });
+    }
+  }
+
+  function buildOption(command, index) {
+    const button = doc.createElement("button");
+    button.type = "button";
+    button.id = `command-${command.id}-${index}`;
+    button.className = "command-palette__command";
+    button.dataset.commandIndex = String(index);
+    button.dataset.commandAction = "execute";
+    button.setAttribute("role", "option");
+
+    const enabled = command.isEnabled();
+    if (!enabled) {
+      button.setAttribute("aria-disabled", "true");
+    }
+
+    const labelWrap = doc.createElement("span");
+    labelWrap.className = "command-palette__command-label";
+
+    const labelText = doc.createElement("span");
+    labelText.textContent = command.getLabel();
+    labelWrap.appendChild(labelText);
+
+    const description = command.getDescription();
+    if (description) {
+      const desc = doc.createElement("span");
+      desc.className = "command-palette__command-description";
+      desc.textContent = description;
+      labelWrap.appendChild(desc);
+    }
+
+    button.appendChild(labelWrap);
+
+    const shortcut = command.getShortcut();
+    if (shortcut) {
+      const shortcutEl = doc.createElement("span");
+      shortcutEl.className = "command-palette__command-shortcut";
+      shortcutEl.textContent = shortcut;
+      button.appendChild(shortcutEl);
+    }
+
+    return button;
+  }
+
+  function renderList() {
+    if (!list) return;
+    list.innerHTML = "";
+    if (filtered.length === 0) {
+      if (emptyState) {
+        emptyState.hidden = false;
+      }
+      activeIndex = -1;
+      updateActiveDescendant();
+      return;
+    }
+    if (emptyState) {
+      emptyState.hidden = true;
+    }
+    filtered.forEach((command, index) => {
+      const option = buildOption(command, index);
+      list.appendChild(option);
+    });
+    activeIndex = filtered.findIndex((command) => command.isEnabled());
+    if (activeIndex < 0 && filtered.length > 0) {
+      activeIndex = 0;
+    }
+    updateActiveDescendant();
+  }
+
+  function applyFilter() {
+    const term = getFilterTerm();
+    filtered = commands.filter((command) => {
+      if (!command.isVisible()) return false;
+      if (!term) return true;
+      const haystack = [
+        command.getLabel(),
+        command.getDescription(),
+        command.getShortcut(),
+        command.keywords,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(term);
+    });
+    renderList();
+  }
+
+  function executeCommand(index) {
+    const command = filtered[index];
+    if (!command || !command.isEnabled()) {
+      return;
+    }
+    close();
+    try {
+      command.run();
+    } catch (error) {
+      console.error("Command execution failed", error);
+    }
+  }
+
+  function moveSelection(delta) {
+    if (filtered.length === 0) return;
+    let nextIndex = activeIndex;
+    const maxIterations = filtered.length;
+    for (let i = 0; i < maxIterations; i += 1) {
+      nextIndex = (nextIndex + delta + filtered.length) % filtered.length;
+      if (filtered[nextIndex].isEnabled()) {
+        activeIndex = nextIndex;
+        updateActiveDescendant();
+        return;
+      }
+    }
+  }
+
+  function open(trigger) {
+    if (isOpen) return;
+    const active = doc.activeElement;
+    if (trigger instanceof HTMLElement) {
+      lastTrigger = trigger;
+    } else if (active instanceof HTMLElement) {
+      lastTrigger = active;
+    } else {
+      lastTrigger = null;
+    }
+    isOpen = true;
+    overlay.hidden = false;
+    overlay.classList.add("is-open");
+    overlay.setAttribute("aria-hidden", "false");
+    lockScroll();
+    if (input) {
+      input.value = "";
+      input.setAttribute("aria-expanded", "true");
+    }
+    applyFilter();
+    requestAnimationFrame(() => {
+      if (input) {
+        focusElement(input);
+      } else if (panel) {
+        focusElement(panel);
+      }
+    });
+  }
+
+  function close() {
+    if (!isOpen) return;
+    isOpen = false;
+    overlay.classList.remove("is-open");
+    overlay.hidden = true;
+    overlay.setAttribute("aria-hidden", "true");
+    unlockScroll();
+    if (input) {
+      input.setAttribute("aria-expanded", "false");
+    }
+    const target = lastTrigger;
+    lastTrigger = null;
+    if (target) {
+      focusElement(target);
+    }
+  }
+
+  function toggle(force, trigger) {
+    if (typeof force === "boolean") {
+      if (force) {
+        open(trigger);
+      } else {
+        close();
+      }
+      return isOpen;
+    }
+    if (isOpen) {
+      close();
+    } else {
+      open(trigger);
+    }
+    return isOpen;
+  }
+
+  function setCommands(nextCommands) {
+    commands = Array.isArray(nextCommands) ? nextCommands.map(normalizeCommand) : [];
+    applyFilter();
+  }
+
+  function handleKeydown(event) {
+    if (!isOpen) return;
+    if (event.key === "Escape") {
+      event.preventDefault();
+      close();
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (activeIndex >= 0) {
+        executeCommand(activeIndex);
+      }
+      return;
+    }
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      moveSelection(1);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      moveSelection(-1);
+    }
+  }
+
+  if (input) {
+    input.addEventListener("input", applyFilter);
+    input.addEventListener("keydown", handleKeydown);
+  }
+
+  if (list) {
+    list.addEventListener("click", (event) => {
+      const button = event.target.closest("[data-command-action]");
+      if (!button) return;
+      const index = Number.parseInt(button.getAttribute("data-command-index"), 10);
+      if (Number.isInteger(index)) {
+        executeCommand(index);
+      }
+    });
+  }
+
+  doc.addEventListener("keydown", (event) => {
+    if (!isOpen) return;
+    if (event.target === input) return;
+    handleKeydown(event);
+  });
+
+  if (backdrop) {
+    backdrop.addEventListener("click", () => {
+      close();
+    });
+  }
+
+  if (closeButton) {
+    closeButton.addEventListener("click", (event) => {
+      event.preventDefault();
+      close();
+    });
+  }
+
+  openers.forEach((opener) => {
+    opener.addEventListener("click", (event) => {
+      event.preventDefault();
+      toggle(true, event.currentTarget);
+    });
+  });
+
+  return {
+    open,
+    close,
+    toggle,
+    setCommands,
+    isOpen: () => isOpen,
+  };
+}

--- a/web/index.html
+++ b/web/index.html
@@ -38,6 +38,26 @@
         <button type="button" class="header-button" id="themeToggle" title="Toggle theme (T)" aria-pressed="false" aria-label="Toggle theme">
           ☀︎
         </button>
+        <button
+          type="button"
+          class="header-button"
+          data-command-open
+          title="Command palette (Cmd/Ctrl+K)"
+          aria-label="Open command palette"
+        >
+          ⌘K
+        </button>
+        <button
+          type="button"
+          class="header-button"
+          id="settingsButton"
+          title="Recorder settings (Cmd/Ctrl+,)"
+          aria-haspopup="dialog"
+          aria-expanded="false"
+          aria-label="Recorder settings"
+        >
+          ⚙
+        </button>
       </div>
     </header>
 
@@ -120,7 +140,7 @@
               <h2>Transcript</h2>
               <span class="transcript-status" data-transcript-status>Transcription requires ASSEMBLYAI_API_KEY.</span>
             </header>
-            <div class="transcript-body" data-transcript-output aria-live="polite"></div>
+            <div class="transcript-body" data-transcript-output aria-live="polite" tabindex="-1"></div>
           </section>
           <section class="log-panel" id="logPanel" aria-live="polite">
             <header class="log-header">
@@ -156,6 +176,92 @@
     <footer class="app-footer" role="contentinfo">
       <span>Press <kbd>?</kbd> for shortcuts.</span>
     </footer>
+  </div>
+
+  <div class="command-palette" data-command-palette hidden aria-hidden="true">
+    <div class="command-palette__backdrop"></div>
+    <section
+      class="command-palette__panel"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="commandPaletteTitle"
+    >
+      <header class="command-palette__header">
+        <h2 id="commandPaletteTitle">Command palette</h2>
+        <button type="button" class="header-button" data-command-close aria-label="Close command palette">×</button>
+      </header>
+      <div class="command-palette__search">
+        <label class="visually-hidden" for="commandPaletteInput">Search commands</label>
+        <input
+          type="search"
+          id="commandPaletteInput"
+          data-command-input
+          placeholder="Search commands…"
+          autocomplete="off"
+          spellcheck="false"
+          role="combobox"
+          aria-controls="commandPaletteList"
+          aria-expanded="false"
+        />
+      </div>
+      <div class="command-palette__results">
+        <div
+          class="command-palette__list"
+          id="commandPaletteList"
+          data-command-list
+          role="listbox"
+          aria-label="Available commands"
+        ></div>
+        <p class="command-palette__empty" data-command-empty hidden>No matching commands.</p>
+      </div>
+      <footer class="command-palette__footer">
+        <span>Use ↑↓ to browse • Enter to run • Esc to close</span>
+      </footer>
+    </section>
+  </div>
+
+  <div class="settings-drawer" data-settings-drawer hidden aria-hidden="true">
+    <div class="settings-drawer__backdrop" data-settings-dismiss></div>
+    <section
+      class="settings-drawer__panel"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="settingsTitle"
+    >
+      <header class="settings-drawer__header">
+        <h2 id="settingsTitle">Recorder settings</h2>
+        <button type="button" class="header-button" data-settings-close aria-label="Close settings">×</button>
+      </header>
+      <div class="settings-drawer__content">
+        <label class="settings-option">
+          <div class="settings-option__details">
+            <span class="settings-option__title">Auto-open transcript</span>
+            <span class="settings-option__description" data-setting-description>
+              Scrolls the transcript pane into view after AssemblyAI returns text.
+            </span>
+          </div>
+          <span class="settings-option__control">
+            <input type="checkbox" data-setting-toggle data-setting-key="autoOpenTranscript" />
+            <span class="settings-option__switch" aria-hidden="true"></span>
+          </span>
+        </label>
+        <label class="settings-option">
+          <div class="settings-option__details">
+            <span class="settings-option__title">Auto-save recording</span>
+            <span class="settings-option__description" data-setting-description>
+              Automatically downloads the clip after you stop recording.
+            </span>
+          </div>
+          <span class="settings-option__control">
+            <input type="checkbox" data-setting-toggle data-setting-key="autoSaveRecording" />
+            <span class="settings-option__switch" aria-hidden="true"></span>
+          </span>
+        </label>
+        <p class="settings-drawer__footnote">
+          Auto-save stores files in your browser&apos;s default downloads folder.
+        </p>
+      </div>
+    </section>
   </div>
 
   <div class="hotkey-overlay" data-modal="hotkeys" data-modal-overlay hidden aria-hidden="true">

--- a/web/style.css
+++ b/web/style.css
@@ -461,6 +461,187 @@ kbd {
   gap: 0.35rem;
 }
 
+.command-palette {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem;
+  z-index: 60;
+}
+
+.command-palette.is-open {
+  display: flex;
+}
+
+.command-palette[hidden] {
+  display: none !important;
+}
+
+.command-palette__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(10, 14, 22, 0.55);
+}
+
+[data-theme="light"] .command-palette__backdrop {
+  background: rgba(10, 14, 22, 0.45);
+}
+
+.command-palette__panel {
+  position: relative;
+  z-index: 1;
+  width: min(560px, 92vw);
+  max-height: min(520px, 90vh);
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+}
+
+.command-palette__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.command-palette__header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.command-palette__search {
+  padding: 0.75rem 1.25rem;
+  border-bottom: 1px solid var(--color-border);
+}
+
+.command-palette__search input {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+  color: inherit;
+  font: inherit;
+  transition: border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
+}
+
+.command-palette__search input:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  background: var(--color-surface);
+  box-shadow: 0 0 0 3px rgba(54, 92, 255, 0.25);
+}
+
+.command-palette__results {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  padding: 0.5rem 0;
+}
+
+.command-palette__list {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0 0.75rem;
+}
+
+.command-palette__command {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  transition: background 0.18s ease, border-color 0.18s ease, transform 0.18s ease;
+}
+
+.command-palette__command:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: 0 0 0 3px rgba(54, 92, 255, 0.25);
+}
+
+.command-palette__command.is-active {
+  background: var(--color-surface-subtle);
+  border-color: var(--color-accent);
+}
+
+.command-palette__command[aria-disabled="true"] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.command-palette__command-label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.command-palette__command-description {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.command-palette__command-shortcut {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.command-palette__empty {
+  margin: 0;
+  padding: 0.5rem 1.25rem 1rem;
+  color: var(--color-muted);
+  font-size: 0.9rem;
+}
+
+.command-palette__empty[hidden] {
+  display: none !important;
+}
+
+.command-palette__footer {
+  padding: 0.75rem 1.25rem;
+  border-top: 1px solid var(--color-border);
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+@media (max-width: 640px) {
+  .command-palette {
+    padding: 1rem;
+  }
+
+  .command-palette__panel {
+    width: min(100%, 96vw);
+  }
+
+  .command-palette__command {
+    align-items: flex-start;
+  }
+
+  .command-palette__command-shortcut {
+    font-size: 0.8rem;
+  }
+}
+
 .hotkey-overlay {
   position: fixed;
   inset: 0;
@@ -1127,3 +1308,421 @@ kbd {
   outline-offset: 2px;
 }
 
+.settings-drawer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: flex-end;
+  pointer-events: none;
+  z-index: 120;
+}
+
+.settings-drawer.is-open {
+  pointer-events: auto;
+}
+
+.settings-drawer__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(12, 20, 38, 0.45);
+  opacity: 0;
+  transition: opacity 160ms ease;
+}
+
+.settings-drawer.is-open .settings-drawer__backdrop {
+  opacity: 1;
+}
+
+.settings-drawer__panel {
+  position: relative;
+  width: min(360px, 100%);
+  height: 100%;
+  background: var(--color-surface);
+  border-left: 1px solid var(--color-border);
+  box-shadow: -24px 0 48px rgba(12, 20, 38, 0.25);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  transform: translateX(18px);
+  transition: transform 200ms ease;
+  overflow-y: auto;
+}
+
+.settings-drawer.is-open .settings-drawer__panel {
+  transform: translateX(0);
+}
+
+.settings-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.settings-drawer__header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.settings-drawer__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.settings-option {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+}
+
+.settings-option__details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.settings-option__title {
+  font-weight: 600;
+}
+
+.settings-option__description {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.settings-option__control {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.6rem;
+}
+
+.settings-option__control input {
+  appearance: none;
+  width: 2.6rem;
+  height: 1.4rem;
+  border-radius: 999px;
+  background: var(--color-border);
+  border: none;
+  outline: none;
+  transition: background 160ms ease;
+  position: relative;
+}
+
+.settings-option__control input:checked {
+  background: var(--color-accent);
+}
+
+.settings-option__switch {
+  position: absolute;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 50%;
+  background: var(--color-surface);
+  left: 0.2rem;
+  box-shadow: var(--shadow-soft);
+  transition: transform 160ms ease;
+}
+
+.settings-option__control input:checked + .settings-option__switch {
+  transform: translateX(1.2rem);
+}
+
+.settings-option__control input:focus-visible {
+  box-shadow: 0 0 0 3px rgba(54, 92, 255, 0.35);
+}
+
+.settings-drawer__footnote {
+  font-size: 0.8rem;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .settings-option {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .settings-option__control {
+    align-self: flex-end;
+  }
+}
+
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+  z-index: 140;
+}
+
+  pointer-events: auto;
+}
+
+  position: absolute;
+  inset: 0;
+  background: rgba(12, 20, 38, 0.45);
+  opacity: 0;
+  transition: opacity 160ms ease;
+}
+
+  opacity: 1;
+}
+
+  position: relative;
+  width: min(520px, calc(100% - 2rem));
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem 1.5rem;
+  transform: translateY(14px);
+  transition: transform 200ms ease;
+}
+
+  transform: translateY(0);
+}
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+  margin: 0;
+  font-size: 1rem;
+}
+
+  border: none;
+  background: none;
+  font-size: 1.25rem;
+  line-height: 1;
+  color: var(--color-muted);
+  padding: 0.25rem;
+}
+
+  color: var(--color-text);
+}
+
+  position: relative;
+}
+
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+  color: var(--color-text);
+  font-size: 0.95rem;
+}
+
+  max-height: 320px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  border: none;
+  background: none;
+  padding: 0.6rem 0.75rem;
+  border-radius: var(--radius-md);
+  font-size: 0.95rem;
+  text-align: left;
+  color: var(--color-text);
+}
+
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+  background: var(--color-surface-subtle);
+  border: 1px solid var(--color-border);
+}
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+  font-size: 0.8rem;
+  color: var(--color-muted);
+}
+
+  font-size: 0.85rem;
+  color: var(--color-muted);
+  text-align: center;
+  margin: 1rem 0;
+}
+
+.settings-drawer {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  justify-content: flex-end;
+  pointer-events: none;
+  z-index: 120;
+}
+
+.settings-drawer.is-open {
+  pointer-events: auto;
+}
+
+.settings-drawer__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(12, 20, 38, 0.45);
+  opacity: 0;
+  transition: opacity 160ms ease;
+}
+
+.settings-drawer.is-open .settings-drawer__backdrop {
+  opacity: 1;
+}
+
+.settings-drawer__panel {
+  position: relative;
+  width: min(360px, 100%);
+  height: 100%;
+  background: var(--color-surface);
+  border-left: 1px solid var(--color-border);
+  box-shadow: -24px 0 48px rgba(12, 20, 38, 0.25);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  transform: translateX(18px);
+  transition: transform 200ms ease;
+  overflow-y: auto;
+}
+
+.settings-drawer.is-open .settings-drawer__panel {
+  transform: translateX(0);
+}
+
+.settings-drawer__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.settings-drawer__header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.settings-drawer__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.settings-option {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.9rem 1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-subtle);
+}
+
+.settings-option__details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.settings-option__title {
+  font-weight: 600;
+}
+
+.settings-option__description {
+  font-size: 0.85rem;
+  color: var(--color-muted);
+}
+
+.settings-option__control {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 2.6rem;
+}
+
+.settings-option__control input {
+  appearance: none;
+  width: 2.6rem;
+  height: 1.4rem;
+  border-radius: 999px;
+  background: var(--color-border);
+  border: none;
+  outline: none;
+  transition: background 160ms ease;
+  position: relative;
+}
+
+.settings-option__control input:checked {
+  background: var(--color-accent);
+}
+
+.settings-option__switch {
+  position: absolute;
+  width: 1.2rem;
+  height: 1.2rem;
+  border-radius: 50%;
+  background: var(--color-surface);
+  left: 0.2rem;
+  box-shadow: var(--shadow-soft);
+  transition: transform 160ms ease;
+}
+
+.settings-option__control input:checked + .settings-option__switch {
+  transform: translateX(1.2rem);
+}
+
+.settings-option__control input:focus-visible {
+  box-shadow: 0 0 0 3px rgba(54, 92, 255, 0.35);
+}
+
+.settings-drawer__footnote {
+  font-size: 0.8rem;
+  color: var(--color-muted);
+  margin: 0;
+}
+
+@media (max-width: 640px) {
+  .settings-option {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .settings-option__control {
+    align-self: flex-end;
+  }
+}


### PR DESCRIPTION
## Summary
- integrate the AssemblyAI transcription pipeline with recorder auto-save/auto-open helpers and status overlay updates
- add an accessible recorder settings drawer so users can toggle transcript auto-open and automatic downloads
- implement a command palette overlay with keyboard and UI entry points plus refreshed README guidance on the workflow

## Risks
- browser-level Cmd/Ctrl shortcuts could still capture some combinations; fall back button provides access when hotkeys are blocked
- auto-save still triggers a download prompt in stricter browsing contexts; users can leave the toggle off if it becomes noisy

## Validation
- `node scripts/fetch_assets.mjs && bash scripts/ensure_icon.sh`
- `bash scripts/start_static.sh && curl -sI http://localhost:1420/ | head -n 1`
- `npx tauri info`
- `npx tauri dev` (stopped after confirming build kickoff)

## Rollback
- `git revert HEAD~3..HEAD`

------
https://chatgpt.com/codex/tasks/task_e_68cca4b14a74832d94e49af6b4c001a4