### PR TITLE
Ensure recorder commands initialize after recorder state

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -731,6 +731,16 @@ function initRecorderPanel() {
   const buttonsByAction = new Map();
   const actionsContainer = recorderRoot.querySelector(".recorder-actions");
   const TRANSCRIBE_DISABLED_MESSAGE = "Transcription unavailable in prod without proxy.";
+  const current = {
+    blob: null,
+    url: null,
+    extension: "ogg",
+    durationMs: 0,
+    size: 0,
+    mimeType: "",
+    autoSaved: false,
+  };
+  let transcribeAbort = null;
   let transcribeTooltipEl = null;
   let activeSettings = getSettingsSnapshot();
   let unsubscribeSettings = null;
@@ -778,18 +788,7 @@ function initRecorderPanel() {
   });
   unregisterRecorderCommands = registerCommandSource("recorder", buildRecorderCommands);
 
-  const current = {
-    blob: null,
-    url: null,
-    extension: "ogg",
-    durationMs: 0,
-    size: 0,
-    mimeType: "",
-    autoSaved: false,
-  };
-
   let isPlaying = false;
-  let transcribeAbort = null;
 
   if (audioEl) {
     audioEl.addEventListener("play", () => {


### PR DESCRIPTION
## Summary
- declare the recorder panel's shared state before wiring up settings subscriptions or command palette suppliers
- rely on the same state in the auto-save callback without triggering the previous ReferenceError during registration

## Rationale
- the command palette pulled recorder actions immediately during registration, but the supplier tried to read `current` before it was initialized, causing a warning each time the panel mounted
- moving the shared state (and other referenced bindings) ahead of the subscription/registration ensures the supplier runs with initialized data and the palette stays in sync

## Validation
- `node scripts/fetch_assets.mjs && bash scripts/ensure_icon.sh`
- `bash scripts/start_static.sh`
- `curl -sI http://localhost:1420/ | head -n 1`
- `npx tauri info`
- `npx tauri dev` *(fails: missing glib-2.0 on the container image)*

## Risks
- UI behaviour was verified by reasoning only because a browser console is unavailable here; if additional synchronous dependencies were missed the palette could still warn

## Rollback
- revert commit 6375542 or reset `web/app.js` to the previous revision and rerun the listed commands


------
https://chatgpt.com/codex/tasks/task_e_68cce1b2c5f0832d8602e959984433a1