### PR TITLE
Ensure settings drawer closes fully off-screen

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -1344,8 +1344,8 @@ kbd {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  transform: translateX(18px);
-  transition: transform 200ms ease;
+  transform: translateX(calc(100% + 24px));
+  transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
   overflow-y: auto;
 }
 
@@ -1613,8 +1613,8 @@ kbd {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  transform: translateX(18px);
-  transition: transform 200ms ease;
+  transform: translateX(calc(100% + 24px));
+  transition: transform 220ms cubic-bezier(0.4, 0, 0.2, 1);
   overflow-y: auto;
 }
 


### PR DESCRIPTION
## Summary
- move the settings drawer panel off-screen when closed so its edge no longer peeks out
- ease the drawer transition with a slightly longer cubic-bezier curve to keep the open/close motion smooth

## Rationale
- the previous 18px translate left a sliver of the panel visible after closing, which is distracting
- ensuring the panel travels completely past its own width (plus the drop shadow) guarantees it disappears cleanly

## Risks
- animation timing might feel inconsistent with other UI motions and could require follow-up tuning

## Testing
- `node scripts/fetch_assets.mjs && bash scripts/ensure_icon.sh`
- `bash scripts/start_static.sh && curl -sI http://localhost:1420/ | head -n 1`
- Manual: toggled the drawer via the gear button, backdrop click, and Escape to confirm it closes fully without peeking
- `npx tauri info` *(fails: npm could not determine executable to run in this environment)*

## Validation
- Visual inspection in Chromium via Playwright confirms the panel is completely hidden after each close trigger.

## Rollback
- Revert this PR.


------
https://chatgpt.com/codex/tasks/task_e_68ccee923b4c832dbf4f6bfca1693d8f